### PR TITLE
feat: Baby Week by Week — Phase 1 foundation

### DIFF
--- a/e2e/home.spec.js
+++ b/e2e/home.spec.js
@@ -1,31 +1,66 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Home page', () => {
+test.describe('Birthday setup screen', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
+  })
+
+  test('shows setup screen when no profile exists', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible()
+    await expect(page.getByLabel(/birthday/i)).toBeVisible()
   })
 
   test('has correct page title', async ({ page }) => {
     await expect(page).toHaveTitle('Baby Week by Week')
   })
 
-  test('shows main heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Baby Week by Week' })).toBeVisible()
+  test('shows error when submitted without a date', async ({ page }) => {
+    await page.getByRole('button', { name: /see this week/i }).click()
+    await expect(page.getByText(/valid birthday/i)).toBeVisible()
   })
 
-  test('shows all 52 weeks loaded', async ({ page }) => {
-    await expect(page.getByText(/52/)).toBeVisible()
+  test('navigates to hero card after entering a birthday', async ({ page }) => {
+    const eightWeeksAgo = new Date(Date.now() - 8 * 7 * 24 * 60 * 60 * 1000)
+    const dateStr = eightWeeksAgo.toISOString().split('T')[0]
+
+    await page.getByLabel(/baby's name/i).fill('Lily')
+    await page.getByLabel(/birthday/i).fill(dateStr)
+    await page.getByRole('button', { name: /see this week/i }).click()
+
+    await expect(page.getByText(/Lily is/i)).toBeVisible()
+    await expect(page.getByText(/Week/)).toBeVisible()
+  })
+})
+
+test.describe('Week hero card', () => {
+  test.beforeEach(async ({ page }) => {
+    // Pre-seed localStorage with a profile (week 8 — full content)
+    const birthday = new Date(Date.now() - 7 * 7 * 24 * 60 * 60 * 1000)
+    await page.addInitScript((birthdayISO) => {
+      localStorage.setItem(
+        'baby_profile',
+        JSON.stringify({ babyName: 'Lily', birthdayISO })
+      )
+    }, birthday.toISOString())
+    await page.goto('/')
   })
 
-  test('shows 13 weeks with full content', async ({ page }) => {
-    await expect(page.getByText(/13/)).toBeVisible()
+  test('shows baby name and week', async ({ page }) => {
+    await expect(page.getByText(/Lily is/i)).toBeVisible()
+    await expect(page.getByText('Week 8')).toBeVisible()
   })
 
-  test('shows Week 8 card with correct title', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Week 8 — 2 months old' })).toBeVisible()
-  })
-
-  test('Week 8 highlight mentions social smiles', async ({ page }) => {
+  test('shows developmental highlight for a full-content week', async ({ page }) => {
     await expect(page.getByText(/social smiles/i)).toBeVisible()
+  })
+
+  test('shows sleep and feeding stats', async ({ page }) => {
+    await expect(page.getByText(/sleep/i)).toBeVisible()
+    await expect(page.getByText(/feeding/i)).toBeVisible()
+  })
+
+  test('change birthday returns to setup screen', async ({ page }) => {
+    await page.getByRole('button', { name: /change birthday/i }).click()
+    await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible()
   })
 })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,22 @@
 import React from 'react'
-import { getWeek, getAllWeeks, getFullWeeks } from './data/index.js'
+import { useBabyProfile } from './hooks/useBabyProfile.js'
+import BirthdaySetup from './components/BirthdaySetup.jsx'
+import WeekHeroCard from './components/WeekHeroCard.jsx'
 
 export default function App() {
-  const allWeeks = getAllWeeks()
-  const fullWeeks = getFullWeeks()
-  const week8 = getWeek(8)
+  const { babyName, currentWeek, setProfile, clearProfile } = useBabyProfile()
+
+  if (!currentWeek) {
+    return <BirthdaySetup onSave={setProfile} />
+  }
 
   return (
-    <div style={{ fontFamily: 'sans-serif', padding: '2rem', maxWidth: '600px', margin: '0 auto' }}>
-      <h1>Baby Week by Week</h1>
-      <p>Total weeks loaded: {allWeeks.length}</p>
-      <p>Weeks with full content: {fullWeeks.length} (weeks 4–16)</p>
-      {week8 && (
-        <div style={{ marginTop: '1rem', padding: '1rem', background: '#faf6f0', borderRadius: '8px' }}>
-          <h2>{week8.title}</h2>
-          <p>{week8.highlight}</p>
-        </div>
-      )}
-    </div>
+    <main className="app">
+      <WeekHeroCard
+        babyName={babyName}
+        currentWeek={currentWeek}
+        onChangeBirthday={clearProfile}
+      />
+    </main>
   )
 }

--- a/src/components/BirthdaySetup.jsx
+++ b/src/components/BirthdaySetup.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+
+/**
+ * Shown on first launch when no baby profile exists.
+ * Collects baby name and birthday, then calls onSave.
+ *
+ * @param {{ onSave: (name: string, birthday: Date) => void }} props
+ */
+export default function BirthdaySetup({ onSave }) {
+  const [name, setName] = useState('')
+  const [dateValue, setDateValue] = useState('')
+  const [error, setError] = useState('')
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+
+    const birthday = new Date(dateValue)
+    const today = new Date()
+    today.setHours(23, 59, 59, 999)
+
+    if (!dateValue || isNaN(birthday.getTime())) {
+      setError('Please enter a valid birthday.')
+      return
+    }
+    if (birthday > today) {
+      setError("Birthday can't be in the future.")
+      return
+    }
+
+    onSave(name.trim() || 'Baby', birthday)
+  }
+
+  // Max date = today, min date = 52 weeks ago
+  const today = new Date().toISOString().split('T')[0]
+  const minDate = new Date(Date.now() - 52 * 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0]
+
+  return (
+    <div className="setup-screen">
+      <div className="setup-card">
+        <h1 className="setup-title">Welcome</h1>
+        <p className="setup-subtitle">
+          Let's get started. When was your baby born?
+        </p>
+
+        <form onSubmit={handleSubmit} className="setup-form">
+          <div className="form-field">
+            <label htmlFor="baby-name">Baby's name <span className="optional">(optional)</span></label>
+            <input
+              id="baby-name"
+              type="text"
+              placeholder="e.g. Lily"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={40}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="birthday">Birthday <span className="required">*</span></label>
+            <input
+              id="birthday"
+              type="date"
+              value={dateValue}
+              onChange={e => setDateValue(e.target.value)}
+              max={today}
+              min={minDate}
+            />
+          </div>
+
+          {error && <p className="form-error">{error}</p>}
+
+          <button type="submit" className="btn-primary">
+            See this week →
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/WeekHeroCard.jsx
+++ b/src/components/WeekHeroCard.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { getWeek } from '../data/index.js'
+
+/**
+ * Hero card displayed on the home screen showing the baby's current week.
+ *
+ * @param {{
+ *   babyName: string,
+ *   currentWeek: number,
+ *   onChangeBirthday: () => void
+ * }} props
+ */
+export default function WeekHeroCard({ babyName, currentWeek, onChangeBirthday }) {
+  const weekData = getWeek(currentWeek)
+
+  const greeting = babyName && babyName !== 'Baby'
+    ? `${babyName} is`
+    : 'Your baby is'
+
+  return (
+    <div className="hero-card">
+      <div className="hero-week-badge">Week {currentWeek}</div>
+
+      <h1 className="hero-title">
+        {greeting} <span className="hero-week-label">{weekData?.ageRange ?? `${currentWeek} weeks old`}</span>
+      </h1>
+
+      {weekData && !weekData.isStub ? (
+        <>
+          <p className="hero-highlight">{weekData.highlight}</p>
+
+          <div className="hero-stats">
+            <div className="hero-stat">
+              <span className="hero-stat-label">Sleep</span>
+              <span className="hero-stat-value">{weekData.sleep.totalHours}</span>
+            </div>
+            <div className="hero-stat">
+              <span className="hero-stat-label">Feeding</span>
+              <span className="hero-stat-value">{weekData.feeding.frequency}</span>
+            </div>
+          </div>
+        </>
+      ) : (
+        <p className="hero-highlight hero-stub">
+          Full content for week {currentWeek} is coming soon.
+        </p>
+      )}
+
+      <button
+        className="btn-ghost hero-change"
+        onClick={onChangeBirthday}
+        aria-label="Change birthday"
+      >
+        Change birthday
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useBabyProfile.js
+++ b/src/hooks/useBabyProfile.js
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react'
+import { getCurrentWeek } from '../data/index.js'
+
+const STORAGE_KEY = 'baby_profile'
+
+/**
+ * Reads and writes the baby profile to localStorage.
+ *
+ * @returns {{
+ *   babyName: string,
+ *   birthday: Date | null,
+ *   currentWeek: number | null,
+ *   setProfile: (name: string, birthday: Date) => void,
+ *   clearProfile: () => void,
+ * }}
+ */
+export function useBabyProfile() {
+  const [profile, setProfileState] = useState(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (!raw) return null
+      const { babyName, birthdayISO } = JSON.parse(raw)
+      return { babyName, birthday: new Date(birthdayISO) }
+    } catch {
+      return null
+    }
+  })
+
+  const setProfile = useCallback((babyName, birthday) => {
+    const data = { babyName, birthdayISO: birthday.toISOString() }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    setProfileState({ babyName, birthday })
+  }, [])
+
+  const clearProfile = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY)
+    setProfileState(null)
+  }, [])
+
+  const currentWeek = profile?.birthday ? getCurrentWeek(profile.birthday) : null
+
+  return {
+    babyName: profile?.babyName ?? '',
+    birthday: profile?.birthday ?? null,
+    currentWeek,
+    setProfile,
+    clearProfile,
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -55,3 +55,195 @@ body {
 #root {
   min-height: 100dvh;
 }
+
+/* ─── App shell ─────────────────────────────────────────── */
+.app {
+  min-height: 100dvh;
+  padding: var(--space-xl) var(--space-md);
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* ─── Buttons ────────────────────────────────────────────── */
+.btn-primary {
+  display: block;
+  width: 100%;
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-primary);
+  color: #fff;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  font-weight: 700;
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.btn-primary:hover  { background: var(--color-primary-dark); }
+.btn-primary:active { background: var(--color-primary-dark); }
+
+.btn-ghost {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: var(--space-xs) 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.btn-ghost:hover { color: var(--color-text); }
+
+/* ─── Birthday setup screen ──────────────────────────────── */
+.setup-screen {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.setup-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2xl) var(--space-xl);
+  width: 100%;
+  max-width: 400px;
+}
+
+.setup-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--color-text);
+  margin-bottom: var(--space-sm);
+}
+
+.setup-subtitle {
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-xl);
+  font-size: 1rem;
+}
+
+.setup-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.form-field label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.form-field input {
+  padding: var(--space-sm) var(--space-md);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 1rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  transition: border-color 0.15s ease;
+  -webkit-appearance: none;
+}
+.form-field input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.optional { color: var(--color-text-muted); font-weight: 400; }
+.required { color: var(--color-primary); }
+
+.form-error {
+  color: #c0392b;
+  font-size: 0.875rem;
+  margin-top: calc(-1 * var(--space-sm));
+}
+
+/* ─── Week hero card ─────────────────────────────────────── */
+.hero-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.hero-week-badge {
+  display: inline-block;
+  background: var(--color-surface-alt);
+  color: var(--color-primary-dark);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  align-self: flex-start;
+}
+
+.hero-title {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  line-height: 1.2;
+  color: var(--color-text);
+}
+
+.hero-week-label {
+  color: var(--color-primary);
+}
+
+.hero-highlight {
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.hero-stub {
+  font-style: italic;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+.hero-stat {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hero-stat-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.hero-stat-value {
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.hero-change {
+  align-self: flex-start;
+  margin-top: var(--space-sm);
+}

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -1,25 +1,67 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../App.jsx'
 
-describe('App', () => {
-  it('renders without crashing', () => {
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+describe('App — no profile set', () => {
+  it('shows the setup screen when no birthday is stored', () => {
     render(<App />)
-    expect(screen.getByText('Baby Week by Week')).toBeInTheDocument()
+    expect(screen.getByText('Welcome')).toBeInTheDocument()
+    expect(screen.getByLabelText(/birthday/i)).toBeInTheDocument()
   })
 
-  it('shows the correct total week count', () => {
+  it('shows a submit button on the setup screen', () => {
     render(<App />)
-    expect(screen.getByText(/52/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /see this week/i })).toBeInTheDocument()
   })
 
-  it('shows the correct full content week count', () => {
+  it('shows an error if submitted without a date', () => {
     render(<App />)
-    expect(screen.getByText(/13/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /see this week/i }))
+    expect(screen.getByText(/valid birthday/i)).toBeInTheDocument()
+  })
+})
+
+describe('App — profile saved', () => {
+  function saveProfile(weeksAgo = 8, name = 'Lily') {
+    const birthday = new Date(Date.now() - weeksAgo * 7 * 24 * 60 * 60 * 1000)
+    localStorage.setItem(
+      'baby_profile',
+      JSON.stringify({ babyName: name, birthdayISO: birthday.toISOString() })
+    )
+  }
+
+  it('shows the hero card when a profile exists', () => {
+    saveProfile(8, 'Lily')
+    render(<App />)
+    expect(screen.getByText(/Week/)).toBeInTheDocument()
+    expect(screen.getByText(/Lily is/i)).toBeInTheDocument()
   })
 
-  it('renders the week 8 highlight text', () => {
+  it('displays the correct week number', () => {
+    saveProfile(8) // 8 weeks ago → week 9
+    render(<App />)
+    expect(screen.getByText('Week 9')).toBeInTheDocument()
+  })
+
+  it('shows week content for a full-content week', () => {
+    saveProfile(7) // 7 weeks ago → week 8 (full content)
     render(<App />)
     expect(screen.getByText(/social smiles/i)).toBeInTheDocument()
+  })
+
+  it('shows stub message for a stub week', () => {
+    saveProfile(1) // 1 week ago → week 2 (stub)
+    render(<App />)
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument()
+  })
+
+  it('clears profile when "Change birthday" is clicked', () => {
+    saveProfile(8)
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /change birthday/i }))
+    expect(screen.getByText('Welcome')).toBeInTheDocument()
   })
 })

--- a/src/test/hooks/useBabyProfile.test.js
+++ b/src/test/hooks/useBabyProfile.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBabyProfile } from '../../hooks/useBabyProfile.js'
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+describe('useBabyProfile', () => {
+  it('returns null currentWeek when no profile is stored', () => {
+    const { result } = renderHook(() => useBabyProfile())
+    expect(result.current.currentWeek).toBeNull()
+    expect(result.current.birthday).toBeNull()
+    expect(result.current.babyName).toBe('')
+  })
+
+  it('setProfile persists to localStorage and updates state', () => {
+    const { result } = renderHook(() => useBabyProfile())
+    const birthday = new Date(Date.now() - 8 * 7 * 24 * 60 * 60 * 1000)
+
+    act(() => result.current.setProfile('Lily', birthday))
+
+    expect(result.current.babyName).toBe('Lily')
+    expect(result.current.birthday).toEqual(birthday)
+    expect(result.current.currentWeek).toBeGreaterThanOrEqual(1)
+    expect(result.current.currentWeek).toBeLessThanOrEqual(52)
+  })
+
+  it('clearProfile removes data from localStorage and resets state', () => {
+    const { result } = renderHook(() => useBabyProfile())
+    const birthday = new Date(Date.now() - 8 * 7 * 24 * 60 * 60 * 1000)
+
+    act(() => result.current.setProfile('Lily', birthday))
+    act(() => result.current.clearProfile())
+
+    expect(result.current.currentWeek).toBeNull()
+    expect(result.current.babyName).toBe('')
+    expect(localStorage.getItem('baby_profile')).toBeNull()
+  })
+
+  it('reads an existing profile from localStorage on mount', () => {
+    const birthday = new Date(Date.now() - 7 * 7 * 24 * 60 * 60 * 1000)
+    localStorage.setItem(
+      'baby_profile',
+      JSON.stringify({ babyName: 'Sam', birthdayISO: birthday.toISOString() })
+    )
+
+    const { result } = renderHook(() => useBabyProfile())
+    expect(result.current.babyName).toBe('Sam')
+    expect(result.current.currentWeek).toBe(8)
+  })
+
+  it('returns null gracefully when localStorage contains invalid JSON', () => {
+    localStorage.setItem('baby_profile', 'not-json')
+    const { result } = renderHook(() => useBabyProfile())
+    expect(result.current.currentWeek).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

This PR establishes the full Phase 1 foundation for the Baby Week by Week PWA, covering issues #1 and #2 from the BRD backlog, plus the complete testing infrastructure.

- **Issue #1** — React + Vite project scaffold, all 52 weeks of structured content (full for weeks 4–16, schema-valid stubs for the rest), and the data layer (`getWeek`, `getAllWeeks`, `getFullWeeks`, `getCurrentWeek`)
- **Issue #2** — Week auto-detection from baby's birthday: onboarding setup screen, `useBabyProfile` hook (localStorage), and the home screen hero card showing the baby's current week with developmental content
- **Testing** — Vitest unit/component tests (39 tests), Playwright E2E tests (Chromium + WebKit/iPhone), GitHub Actions CI (unit + E2E jobs on PR), Husky pre-push hook

## What's included

### Project scaffold
- React 18 + Vite 5, PWA manifest + service worker stub
- Design tokens (warm palette: terracotta, sage, cream)

### Week content (`src/data/weeks/`)
- 52 week files — full content for weeks 4–16, stubs for the rest
- `WeekEntry` schema: highlight, physical, cognitive, sleep, feeding, play, parent tips
- Data helpers: `getWeek(n)`, `getAllWeeks()`, `getFullWeeks()`, `getCurrentWeek(birthday)`

### Home screen
- `BirthdaySetup` — onboarding form (baby name + date picker, JS validation)
- `useBabyProfile` — hook reading/writing baby profile to localStorage
- `WeekHeroCard` — hero card with week badge, age, developmental highlight, sleep/feeding stats

### Testing
- 39 Vitest tests: data layer, schema conformance, `useBabyProfile` hook, App integration
- Playwright E2E: setup flow, hero card rendering, localStorage seeding, Chromium + WebKit
- GitHub Actions CI: unit tests + build on every push; Playwright on PRs only
- Husky: `npm test` runs before every push

## Test plan

- [ ] `npm install && npm run dev` → app loads at `http://localhost:5173`
- [ ] Setup screen shown on first visit, accepts baby name + birthday
- [ ] Hero card displays correct week number and content after setup
- [ ] "Change birthday" resets to setup screen
- [ ] `npm test` → 39 tests pass
- [ ] `npm run build` → clean production build

https://claude.ai/code/session_01JZArCXQA2T7AKUNjjA9ira