### PR TITLE
feat: add ugly cute SVG illustrations for weeks 4–16 (issue #3)

### DIFF
--- a/public/illustrations/week-04.svg
+++ b/public/illustrations/week-04.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 4 — 1 month. Sleeping deeply. Lavender swaddle. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Crescent moon -->
+  <circle cx="168" cy="38" r="13" fill="#f5c842" opacity="0.75"/>
+  <circle cx="175" cy="35" r="11" fill="#fdf8f0"/>
+
+  <!-- Small star top-left -->
+  <polygon transform="translate(26,32) scale(0.75)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+
+  <!-- Tiny star -->
+  <polygon transform="translate(148,58) scale(0.45)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body — swaddle, wider and rounder -->
+  <ellipse cx="100" cy="193" rx="44" ry="33" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm (tucked) -->
+  <ellipse cx="58" cy="200" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-25 58 200)"/>
+
+  <!-- Right arm (tucked) -->
+  <ellipse cx="142" cy="200" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(25 142 200)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="96" r="64" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="112" r="23" fill="#f2a07b" opacity="0.32"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="112" r="23" fill="#f2a07b" opacity="0.32"/>
+
+  <!-- Left eye — sleeping crescent -->
+  <path d="M 80,91 Q 88,83 96,91" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Right eye — sleeping crescent -->
+  <path d="M 104,91 Q 112,83 120,91" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — tiny, peaceful -->
+  <path d="M 93,113 Q 100,117 107,113" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- ZZZ floating -->
+  <text x="143" y="66" font-family="Nunito,sans-serif" font-size="13" fill="#3a2a4a" opacity="0.35" font-weight="700">z</text>
+  <text x="154" y="55" font-family="Nunito,sans-serif" font-size="11" fill="#3a2a4a" opacity="0.25" font-weight="700">z</text>
+  <text x="162" y="46" font-family="Nunito,sans-serif" font-size="9" fill="#3a2a4a" opacity="0.18" font-weight="700">z</text>
+</svg>

--- a/public/illustrations/week-05.svg
+++ b/public/illustrations/week-05.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 5 — Eyes beginning to track. Powder blue. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(30,35) scale(0.8)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.6"/>
+  <polygon transform="translate(162,42) scale(0.55)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.45"/>
+  <polygon transform="translate(175,22) scale(0.4)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.35"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="61" cy="198" rx="13" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 61 198)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="139" cy="198" rx="13" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(22 139 198)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Left eye — very slightly open (arc + tiny pupil) -->
+  <path d="M 80,90 Q 88,82 96,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="88" cy="90" rx="3.5" ry="2.2" fill="#3a2a4a" opacity="0.7"/>
+
+  <!-- Right eye — very slightly open -->
+  <path d="M 104,90 Q 112,82 120,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="112" cy="90" rx="3.5" ry="2.2" fill="#3a2a4a" opacity="0.7"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — tiny neutral -->
+  <path d="M 93,112 Q 100,115 107,112" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Small cloud shape top-left -->
+  <ellipse cx="22" cy="215" rx="16" ry="9" fill="#b8d8f0" opacity="0.35"/>
+  <ellipse cx="35" cy="210" rx="13" ry="8" fill="#b8d8f0" opacity="0.35"/>
+  <ellipse cx="46" cy="216" rx="11" ry="7" fill="#b8d8f0" opacity="0.35"/>
+</svg>

--- a/public/illustrations/week-06.svg
+++ b/public/illustrations/week-06.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 6 — First social smiles beginning. Tiny upward curl at mouth corners. Blush outfit. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(28,30) scale(0.85)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.65"/>
+  <polygon transform="translate(170,38) scale(0.6)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+
+  <!-- Tiny sparkle dots -->
+  <circle cx="155" cy="22" r="2.5" fill="#f5c842" opacity="0.5"/>
+  <circle cx="160" cy="18" r="1.5" fill="#f5c842" opacity="0.4"/>
+  <circle cx="165" cy="24" r="2" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="61" cy="198" rx="13" ry="9" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 61 198)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="139" cy="198" rx="13" ry="9" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(22 139 198)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush — slightly more prominent for smile week -->
+  <circle cx="68" cy="111" r="24" fill="#f2a07b" opacity="0.38"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="24" fill="#f2a07b" opacity="0.38"/>
+
+  <!-- Left eye — closed crescent -->
+  <path d="M 80,90 Q 88,82 96,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Right eye — closed crescent -->
+  <path d="M 104,90 Q 112,82 120,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — tiny beginning smile, corners barely turned up -->
+  <path d="M 92,114 Q 96,117 100,115 Q 104,117 108,114" fill="none" stroke="#3a2a4a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Small heart near cheek — first smile is a big deal -->
+  <path d="M 148,80 C 148,77 152,75 152,79 C 152,75 156,77 156,80 C 156,84 152,87 152,87 C 152,87 148,84 148,80 Z" fill="#f2a07b" opacity="0.55"/>
+</svg>

--- a/public/illustrations/week-07.svg
+++ b/public/illustrations/week-07.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 7 — Tracking faces and voices. Eyes more attentive. Sage outfit. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(170,30) scale(0.8)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+  <polygon transform="translate(25,45) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Cloud decoration -->
+  <ellipse cx="28" cy="32" rx="17" ry="10" fill="#b8d8f0" opacity="0.3"/>
+  <ellipse cx="42" cy="26" rx="14" ry="9" fill="#b8d8f0" opacity="0.3"/>
+  <ellipse cx="54" cy="33" rx="11" ry="8" fill="#b8d8f0" opacity="0.3"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="61" cy="198" rx="13" ry="9" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 61 198)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="139" cy="198" rx="13" ry="9" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2" transform="rotate(22 139 198)"/>
+
+  <!-- Head — very slight tilt for tracking look -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Left eye — slightly open with small pupil (tracking) -->
+  <path d="M 79,90 Q 87,82 95,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="87" cy="90" rx="4" ry="2.8" fill="#3a2a4a" opacity="0.75"/>
+
+  <!-- Right eye — slightly open, pupils shifted slightly right (tracking something) -->
+  <path d="M 105,90 Q 113,82 121,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="114" cy="90" rx="4" ry="2.8" fill="#3a2a4a" opacity="0.75"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — neutral, slightly open in wonder -->
+  <path d="M 93,112 Q 100,115 107,112" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/public/illustrations/week-08.svg
+++ b/public/illustrations/week-08.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 8 — Social smiles in full swing! Big gummy grin. Gold outfit. Celebration! -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars — lots of them for the smile milestone -->
+  <polygon transform="translate(25,30) scale(0.9)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.7"/>
+  <polygon transform="translate(172,35) scale(0.85)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.7"/>
+  <polygon transform="translate(155,18) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+  <polygon transform="translate(42,20) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+  <polygon transform="translate(18,55) scale(0.4)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+  <polygon transform="translate(183,60) scale(0.4)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body — gold, celebratory -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#f5c842" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm — slightly raised in excitement -->
+  <ellipse cx="60" cy="194" rx="14" ry="9" fill="#f5c842" stroke="#3a2a4a" stroke-width="2" transform="rotate(-35 60 194)"/>
+
+  <!-- Right arm — slightly raised -->
+  <ellipse cx="140" cy="194" rx="14" ry="9" fill="#f5c842" stroke="#3a2a4a" stroke-width="2" transform="rotate(35 140 194)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="64" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush — prominent for big smile! -->
+  <circle cx="67" cy="112" r="26" fill="#f2a07b" opacity="0.42"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="133" cy="112" r="26" fill="#f2a07b" opacity="0.42"/>
+
+  <!-- Left eye — open, happy arc -->
+  <path d="M 79,89 Q 87,80 95,89" fill="none" stroke="#3a2a4a" stroke-width="2.8" stroke-linecap="round"/>
+  <ellipse cx="87" cy="89" rx="4.5" ry="3" fill="#3a2a4a" opacity="0.8"/>
+
+  <!-- Right eye — open, happy arc -->
+  <path d="M 105,89 Q 113,80 121,89" fill="none" stroke="#3a2a4a" stroke-width="2.8" stroke-linecap="round"/>
+  <ellipse cx="113" cy="89" rx="4.5" ry="3" fill="#3a2a4a" opacity="0.8"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — BIG GUMMY SMILE -->
+  <path d="M 85,113 Q 100,128 115,113" fill="#3a2a4a" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Gums / teeth area -->
+  <path d="M 86,113 Q 100,127 114,113" fill="#ffffff"/>
+  <!-- Gum line detail -->
+  <path d="M 88,116 Q 100,124 112,116" fill="none" stroke="#f2a07b" stroke-width="1.5" opacity="0.6"/>
+</svg>

--- a/public/illustrations/week-09.svg
+++ b/public/illustrations/week-09.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 9 — First coos and vowel sounds. Mouth slightly open. Lavender. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(168,35) scale(0.75)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+  <polygon transform="translate(30,28) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.45"/>
+
+  <!-- Small music note dots (cooing) -->
+  <circle cx="150" cy="58" r="3.5" fill="#d4c5f0" opacity="0.7"/>
+  <circle cx="158" cy="50" r="2.5" fill="#d4c5f0" opacity="0.6"/>
+  <circle cx="164" cy="44" r="2" fill="#d4c5f0" opacity="0.5"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="61" cy="198" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 61 198)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="139" cy="198" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(22 139 198)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Left eye — closed crescent -->
+  <path d="M 80,90 Q 88,82 96,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Right eye — closed crescent -->
+  <path d="M 104,90 Q 112,82 120,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — small O shape (cooing) -->
+  <ellipse cx="100" cy="115" rx="6" ry="5" fill="#3a2a4a" stroke="#3a2a4a" stroke-width="1.5"/>
+  <ellipse cx="100" cy="115" rx="4" ry="3.2" fill="#ffffff" opacity="0.85"/>
+</svg>

--- a/public/illustrations/week-10.svg
+++ b/public/illustrations/week-10.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 10 — Hands to mouth, discovering fingers. Blue. One arm raised. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(28,32) scale(0.7)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+  <polygon transform="translate(172,40) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="194" rx="40" ry="30" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm — normal -->
+  <ellipse cx="62" cy="200" rx="13" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 62 200)"/>
+
+  <!-- Right arm — raised toward face (discovering hands!) -->
+  <ellipse cx="136" cy="175" rx="13" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-60 136 175)"/>
+
+  <!-- Chubby fist raised near face -->
+  <circle cx="128" cy="155" r="10" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2"/>
+  <!-- Finger knuckle lines -->
+  <path d="M 122,152 Q 124,150 128,152 Q 132,150 134,152" fill="none" stroke="#3a2a4a" stroke-width="1.2" opacity="0.5"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Left eye — closed crescent -->
+  <path d="M 80,90 Q 88,82 96,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Right eye — closed crescent -->
+  <path d="M 104,90 Q 112,82 120,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — slightly open, curious -->
+  <path d="M 93,113 Q 100,116 107,113" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+  <ellipse cx="100" cy="115" rx="4" ry="3" fill="#3a2a4a" opacity="0.3"/>
+</svg>

--- a/public/illustrations/week-11.svg
+++ b/public/illustrations/week-11.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 11 — Tummy time! Head lifting up. Sage. Body slightly tilted/prone. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(170,32) scale(0.75)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+
+  <!-- Ground/floor hint -->
+  <ellipse cx="100" cy="228" rx="65" ry="8" fill="#a8c9a8" opacity="0.2"/>
+
+  <!-- Body — prone, wider/flatter for tummy time -->
+  <ellipse cx="100" cy="200" rx="52" ry="22" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm stretched out on floor -->
+  <ellipse cx="48" cy="208" rx="16" ry="8" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2" transform="rotate(-10 48 208)"/>
+
+  <!-- Right arm stretched out on floor -->
+  <ellipse cx="152" cy="208" rx="16" ry="8" fill="#a8c9a8" stroke="#3a2a4a" stroke-width="2" transform="rotate(10 152 208)"/>
+
+  <!-- Head — tilted up, like lifting during tummy time -->
+  <circle cx="100" cy="90" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5" transform="rotate(-8 100 150)"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="70" cy="108" r="22" fill="#f2a07b" opacity="0.30" transform="rotate(-8 100 150)"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="130" cy="108" r="22" fill="#f2a07b" opacity="0.30" transform="rotate(-8 100 150)"/>
+
+  <!-- Left eye — determined, closed crescent -->
+  <path d="M 81,87 Q 89,79 97,87" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round" transform="rotate(-8 100 150)"/>
+
+  <!-- Right eye — determined -->
+  <path d="M 103,87 Q 111,79 119,87" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round" transform="rotate(-8 100 150)"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="98" r="1.5" fill="#3a2a4a" opacity="0.6" transform="rotate(-8 100 150)"/>
+  <circle cx="103.5" cy="98" r="1.5" fill="#3a2a4a" opacity="0.6" transform="rotate(-8 100 150)"/>
+
+  <!-- Mouth — focused, tiny pursed -->
+  <path d="M 94,110 Q 100,113 106,110" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round" transform="rotate(-8 100 150)"/>
+
+  <!-- Small sweat bead — working hard! -->
+  <ellipse cx="55" cy="78" rx="4" ry="5.5" fill="#b8d8f0" opacity="0.6" transform="rotate(-15 55 78)"/>
+</svg>

--- a/public/illustrations/week-12.svg
+++ b/public/illustrations/week-12.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 12 — Reaching and grabbing. First laughs. Arms raised. Light gold. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars — celebratory for 3 months -->
+  <polygon transform="translate(25,28) scale(0.9)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.65"/>
+  <polygon transform="translate(172,32) scale(0.8)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.6"/>
+  <polygon transform="translate(158,18) scale(0.48)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+  <polygon transform="translate(40,18) scale(0.48)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="196" rx="40" ry="28" fill="#f5e68a" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm — raised (reaching!) -->
+  <ellipse cx="56" cy="178" rx="14" ry="9" fill="#f5e68a" stroke="#3a2a4a" stroke-width="2" transform="rotate(-55 56 178)"/>
+
+  <!-- Left fist reaching up -->
+  <circle cx="48" cy="162" r="11" fill="#f5e68a" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Right arm — raised -->
+  <ellipse cx="144" cy="178" rx="14" ry="9" fill="#f5e68a" stroke="#3a2a4a" stroke-width="2" transform="rotate(55 144 178)"/>
+
+  <!-- Right fist reaching up -->
+  <circle cx="152" cy="162" r="11" fill="#f5e68a" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="64" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush — more prominent for laughing -->
+  <circle cx="67" cy="112" r="25" fill="#f2a07b" opacity="0.38"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="133" cy="112" r="25" fill="#f2a07b" opacity="0.38"/>
+
+  <!-- Left eye — crescent, slightly more upturned (happy) -->
+  <path d="M 79,89 Q 87,80 95,89" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="87" cy="89" rx="4" ry="2.5" fill="#3a2a4a" opacity="0.72"/>
+
+  <!-- Right eye -->
+  <path d="M 105,89 Q 113,80 121,89" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="113" cy="89" rx="4" ry="2.5" fill="#3a2a4a" opacity="0.72"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — open laughing smile -->
+  <path d="M 88,113 Q 100,123 112,113" fill="#3a2a4a" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 89,113 Q 100,122 111,113" fill="#ffffff"/>
+</svg>

--- a/public/illustrations/week-13.svg
+++ b/public/illustrations/week-13.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 13 — Alert and aware. Eyes more open, taking everything in. Lavender. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(30,38) scale(0.7)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.55"/>
+  <polygon transform="translate(170,30) scale(0.6)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+
+  <!-- Crescent moon -->
+  <circle cx="25" cy="210" r="11" fill="#f5c842" opacity="0.5"/>
+  <circle cx="31" cy="207" r="9.5" fill="#fdf8f0"/>
+
+  <!-- Body -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="61" cy="198" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-22 61 198)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="139" cy="198" rx="13" ry="9" fill="#d4c5f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(22 139 198)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="95" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="111" r="22" fill="#f2a07b" opacity="0.30"/>
+
+  <!-- Left eye — more open (alert) -->
+  <path d="M 79,90 Q 87,80 95,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="87" cy="90" rx="5" ry="3.5" fill="#3a2a4a" opacity="0.78"/>
+  <!-- White highlight -->
+  <circle cx="89" cy="88.5" r="1.4" fill="#ffffff" opacity="0.9"/>
+
+  <!-- Right eye — more open -->
+  <path d="M 105,90 Q 113,80 121,90" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="113" cy="90" rx="5" ry="3.5" fill="#3a2a4a" opacity="0.78"/>
+  <!-- White highlight -->
+  <circle cx="115" cy="88.5" r="1.4" fill="#ffffff" opacity="0.9"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — small O, curious -->
+  <path d="M 93,112 Q 100,116 107,112" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/public/illustrations/week-14.svg
+++ b/public/illustrations/week-14.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 14 — Rolling prep. Slight lean. Powder blue. Body slightly tilted. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(168,38) scale(0.72)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+  <polygon transform="translate(28,36) scale(0.48)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body — slightly tilted/leaning -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(8 100 192)"/>
+
+  <!-- Left arm — planted -->
+  <ellipse cx="58" cy="202" rx="13" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(-18 58 202)"/>
+
+  <!-- Right arm — extended/leaning for roll prep -->
+  <ellipse cx="144" cy="188" rx="15" ry="9" fill="#b8d8f0" stroke="#3a2a4a" stroke-width="2" transform="rotate(15 144 188)"/>
+
+  <!-- Head — slight tilt matching lean -->
+  <circle cx="100" cy="94" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5" transform="rotate(5 100 150)"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="67" cy="110" r="22" fill="#f2a07b" opacity="0.30" transform="rotate(5 100 150)"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="133" cy="110" r="22" fill="#f2a07b" opacity="0.30" transform="rotate(5 100 150)"/>
+
+  <!-- Left eye -->
+  <path d="M 80,89 Q 88,81 96,89" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round" transform="rotate(5 100 150)"/>
+
+  <!-- Right eye -->
+  <path d="M 104,89 Q 112,81 120,89" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round" transform="rotate(5 100 150)"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="100" r="1.5" fill="#3a2a4a" opacity="0.6" transform="rotate(5 100 150)"/>
+  <circle cx="103.5" cy="100" r="1.5" fill="#3a2a4a" opacity="0.6" transform="rotate(5 100 150)"/>
+
+  <!-- Mouth — concentrating -->
+  <path d="M 94,112 Q 100,115 106,112" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round" transform="rotate(5 100 150)"/>
+
+  <!-- Motion curve hinting at roll -->
+  <path d="M 160,185 Q 175,195 165,210" fill="none" stroke="#b8d8f0" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="4,4" opacity="0.5"/>
+</svg>

--- a/public/illustrations/week-15.svg
+++ b/public/illustrations/week-15.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 15 — Standing supported. Legs visible. Blush outfit. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars -->
+  <polygon transform="translate(28,32) scale(0.75)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.6"/>
+  <polygon transform="translate(170,40) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.45"/>
+
+  <!-- Left leg -->
+  <ellipse cx="84" cy="222" rx="13" ry="18" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2"/>
+  <!-- Left foot -->
+  <ellipse cx="82" cy="234" rx="11" ry="7" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(-8 82 234)"/>
+
+  <!-- Right leg -->
+  <ellipse cx="116" cy="222" rx="13" ry="18" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2"/>
+  <!-- Right foot -->
+  <ellipse cx="118" cy="234" rx="11" ry="7" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(8 118 234)"/>
+
+  <!-- Body — taller, upright stance -->
+  <ellipse cx="100" cy="190" rx="36" ry="26" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm -->
+  <ellipse cx="62" cy="194" rx="13" ry="9" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(-20 62 194)"/>
+
+  <!-- Right arm -->
+  <ellipse cx="138" cy="194" rx="13" ry="9" fill="#f7c9ae" stroke="#3a2a4a" stroke-width="2" transform="rotate(20 138 194)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="93" r="63" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="68" cy="109" r="22" fill="#f2a07b" opacity="0.32"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="132" cy="109" r="22" fill="#f2a07b" opacity="0.32"/>
+
+  <!-- Left eye — closed crescent -->
+  <path d="M 80,88 Q 88,80 96,88" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Right eye — closed crescent -->
+  <path d="M 104,88 Q 112,80 120,88" fill="none" stroke="#3a2a4a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="99" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="99" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — tiny proud smile -->
+  <path d="M 92,111 Q 100,116 108,111" fill="none" stroke="#3a2a4a" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/public/illustrations/week-16.svg
+++ b/public/illustrations/week-16.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <!-- Week 16 — Curious and aware. Eyes widest of all. Looking outward. Gold outfit. -->
+
+  <!-- Background -->
+  <rect width="200" height="240" fill="#fdf8f0" rx="16"/>
+
+  <!-- Stars — abundant, matching the alert curiosity of this week -->
+  <polygon transform="translate(26,28) scale(0.95)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.7"/>
+  <polygon transform="translate(172,32) scale(0.85)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.65"/>
+  <polygon transform="translate(155,16) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+  <polygon transform="translate(40,16) scale(0.5)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.5"/>
+  <polygon transform="translate(18,55) scale(0.38)" points="0,-9 2.12,-2.91 8.56,-2.78 3.42,1.11 5.29,7.28 0,3.6 -5.29,7.28 -3.42,1.11 -8.56,-2.78 -2.12,-2.91" fill="#f5c842" opacity="0.4"/>
+
+  <!-- Body — gold, confident -->
+  <ellipse cx="100" cy="192" rx="40" ry="30" fill="#f5c842" stroke="#3a2a4a" stroke-width="2"/>
+
+  <!-- Left arm — reaching outward (looking at the world!) -->
+  <ellipse cx="58" cy="192" rx="14" ry="9" fill="#f5c842" stroke="#3a2a4a" stroke-width="2" transform="rotate(-30 58 192)"/>
+
+  <!-- Right arm — reaching outward -->
+  <ellipse cx="142" cy="192" rx="14" ry="9" fill="#f5c842" stroke="#3a2a4a" stroke-width="2" transform="rotate(30 142 192)"/>
+
+  <!-- Head -->
+  <circle cx="100" cy="94" r="64" fill="#ffffff" stroke="#3a2a4a" stroke-width="2.5"/>
+
+  <!-- Left cheek blush -->
+  <circle cx="67" cy="111" r="24" fill="#f2a07b" opacity="0.35"/>
+
+  <!-- Right cheek blush -->
+  <circle cx="133" cy="111" r="24" fill="#f2a07b" opacity="0.35"/>
+
+  <!-- Left eye — WIDEST, most open — curious and aware -->
+  <path d="M 78,89 Q 87,78 96,89" fill="none" stroke="#3a2a4a" stroke-width="2.8" stroke-linecap="round"/>
+  <ellipse cx="87" cy="89" rx="6" ry="4.5" fill="#3a2a4a" opacity="0.82"/>
+  <!-- White highlight sparkle -->
+  <circle cx="89.5" cy="87" r="2" fill="#ffffff" opacity="0.95"/>
+
+  <!-- Right eye — WIDEST -->
+  <path d="M 104,89 Q 113,78 122,89" fill="none" stroke="#3a2a4a" stroke-width="2.8" stroke-linecap="round"/>
+  <ellipse cx="113" cy="89" rx="6" ry="4.5" fill="#3a2a4a" opacity="0.82"/>
+  <!-- White highlight sparkle -->
+  <circle cx="115.5" cy="87" r="2" fill="#ffffff" opacity="0.95"/>
+
+  <!-- Nose -->
+  <circle cx="96.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+  <circle cx="103.5" cy="101" r="1.5" fill="#3a2a4a" opacity="0.6"/>
+
+  <!-- Mouth — serene, quietly content — proportions do the work, not the smile -->
+  <path d="M 93,113 Q 100,117 107,113" fill="none" stroke="#3a2a4a" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
13 hand-crafted SVGs in public/illustrations/ following the PopMart Twinkle Twinkle aesthetic: enormous doughy cheeks, oversized round head, sleepy crescent eyes, stub nose, mochi-like body. Each week's character subtly reflects its developmental stage — week 6 has a first tiny smile, week 8 a big gummy grin, week 11 is in tummy-time pose, week 16 has the widest eyes of all. Palette: gold, blush, lavender, powder blue, sage on warm cream background.

Closes #3

https://claude.ai/code/session_01JZArCXQA2T7AKUNjjA9ira