### PR TITLE
Fill all 52 weeks with developmental content and daily facts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ function BottomNav({ activeTab, onTabChange }) {
 
 function AppShell() {
   const { user } = useAuth()
-  const { babyName, currentWeek, setProfile, clearProfile } = useBabyProfile()
+  const { babyName, birthday, currentWeek, setProfile, clearProfile } = useBabyProfile()
   const [tab, setTab] = useState('home')
   const [selectedWeek, setSelectedWeek] = useState(null)
 
@@ -83,6 +83,7 @@ function AppShell() {
             >
               <HomeScreen
                 babyName={babyName}
+                birthday={birthday}
                 currentWeek={currentWeek}
                 onChangeBirthday={clearProfile}
                 onGoToChat={() => setTab('account')}

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -1,21 +1,24 @@
 import React, { useState } from 'react'
 import { motion } from 'motion/react'
 import BabyCharacter from './BabyCharacter.jsx'
-import { getWeek } from '../data/index.js'
+import { getWeek, getCurrentDayOfWeek } from '../data/index.js'
 
 /**
- * Home tab — shows the current week card, BabyCharacter, this week's
- * watch-for milestones (checkable), and the AI upsell banner.
+ * Home tab — shows the current week card, BabyCharacter, today's daily fact,
+ * this week's watch-for milestones (checkable), and the AI upsell banner.
  *
  * @param {{
  *   babyName: string,
+ *   birthday: Date,
  *   currentWeek: number,
  *   onChangeBirthday: () => void,
  *   onGoToChat: () => void,
  * }} props
  */
-export default function HomeScreen({ babyName, currentWeek, onChangeBirthday, onGoToChat }) {
+export default function HomeScreen({ babyName, birthday, currentWeek, onChangeBirthday, onGoToChat }) {
   const weekData = getWeek(currentWeek)
+  const dayOfWeek = birthday ? getCurrentDayOfWeek(birthday) : 0
+  const todaysFact = weekData?.dailyFacts?.[dayOfWeek] ?? null
 
   // Derive per-week milestone items from watchFor array
   const milestoneItems = weekData?.parentTips?.watchFor?.map((text, i) => ({
@@ -77,6 +80,19 @@ export default function HomeScreen({ babyName, currentWeek, onChangeBirthday, on
           Change birthday
         </button>
       </div>
+
+      {/* Today's daily fact */}
+      {todaysFact && (
+        <motion.div
+          className="home-daily-fact"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+        >
+          <span className="home-daily-fact-label">Today</span>
+          <p className="home-daily-fact-text">{todaysFact}</p>
+        </motion.div>
+      )}
 
       {/* This week's milestones */}
       {milestoneItems.length > 0 && (

--- a/src/components/WeekContent.jsx
+++ b/src/components/WeekContent.jsx
@@ -96,6 +96,26 @@ export default function WeekContent({ week, onBack }) {
             </ul>
           </motion.div>
         )}
+
+        {/* Daily facts */}
+        {data && !data.isStub && data.dailyFacts?.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: (sections.length + 1) * 0.05 }}
+            className="week-section"
+          >
+            <h4 className="week-section-title">Daily insights</h4>
+            <ol className="week-daily-list">
+              {data.dailyFacts.map((fact, i) => (
+                <li key={i} className="week-daily-item">
+                  <span className="week-daily-day">Day {i + 1}</span>
+                  <span className="week-daily-text">{fact}</span>
+                </li>
+              ))}
+            </ol>
+          </motion.div>
+        )}
       </div>
     </div>
   )

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -153,3 +153,15 @@ export function getCurrentWeek(birthday) {
   const ageInWeeks = Math.floor((Date.now() - birthday.getTime()) / msPerWeek) + 1
   return Math.max(1, Math.min(52, ageInWeeks))
 }
+
+/**
+ * Returns the day index (0–6) within the current week based on birthday.
+ * Day 0 = first day of the week, day 6 = seventh day.
+ * @param {Date} birthday
+ * @returns {number}
+ */
+export function getCurrentDayOfWeek(birthday) {
+  const msPerDay = 24 * 60 * 60 * 1000
+  const ageInDays = Math.floor((Date.now() - birthday.getTime()) / msPerDay)
+  return ageInDays % 7
+}

--- a/src/data/schema.js
+++ b/src/data/schema.js
@@ -62,6 +62,7 @@
  * @property {FeedingInfo}        feeding
  * @property {PlayActivities}     play
  * @property {ParentTips}         parentTips
+ * @property {string[]}           dailyFacts  7 short facts or tips, one per day of the week (index 0 = day 1, index 6 = day 7)
  * @property {boolean}            isStub      True when content is placeholder; false when fully written
  */
 

--- a/src/data/weeks/week-01.js
+++ b/src/data/weeks/week-01.js
@@ -1,15 +1,77 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week01 = {
   week: 1,
-  ageRange: '0–1 week old',
-  title: 'Week 1 — 0–1 week old',
+  ageRange: '0–7 days old',
+  title: 'Week 1 — Welcome to the world',
+  highlight:
+    'Your baby has arrived. Everything is new — for them, and for you. This first week is raw, overwhelming, and extraordinary all at once. There is no right way to feel.',
   illustration: '/illustrations/baby-01.png',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  physical: {
+    size: '~2.7–4.0 kg / 6–8.8 lbs at birth, ~48–53 cm / 19–21 in — expect a 7–10% weight dip in the first few days',
+    motorSkills:
+      'All movements are reflex-driven — there is no intentional motor control yet. Limbs move in jerky, uncoordinated bursts. When awake and alert, expect vigorous arm and leg movements. Your baby\'s fists are almost always clenched.',
+    reflexes:
+      'Rooting (turning toward touch on the cheek), sucking, Moro startle, palmar grasp, and Babinski reflexes are all present from birth. These aren\'t cute quirks — they are survival mechanisms millions of years in the making.',
+  },
+  cognitive: {
+    vision:
+      'Newborns can see best at 20–30 cm — roughly the distance between your face and theirs during feeding. Vision is blurry beyond that. High-contrast shapes (black and white, bold patterns) capture their attention most. Human faces are already preferred over objects.',
+    hearing:
+      'Your baby\'s hearing is fully developed at birth. They recognise your voice — they\'ve been listening since around 26 weeks in the womb. Sudden loud noises trigger the Moro reflex. Familiar voices are genuinely calming.',
+    awareness:
+      'Most of the time your baby is either asleep or in a drowsy state. Brief quiet-alert windows — just minutes at a time — are when they take in the world. Don\'t expect much sustained eye contact yet. It\'s coming.',
+  },
+  sleep: {
+    totalHours: '16–20 hours/day',
+    nightSleep: 'No day/night distinction yet — waking every 1–3 hours around the clock',
+    naps: 'Sleep happens in short cycles throughout the day, not consolidated stretches',
+    notes:
+      'Your baby\'s circadian rhythm is not yet developed — they have no concept of night and day. This is not a problem to fix, it\'s a developmental stage to survive. Keeping nights dark and quiet (no phone screens, low voices) starts laying the groundwork, but don\'t expect results this week.',
+  },
+  feeding: {
+    amount: 'Colostrum: ~5–7 ml per feed (about a teaspoon) — tiny amounts, but concentrated and exactly right',
+    frequency: 'Every 1.5–3 hours, 8–12 feeds per day — feed on demand, not by the clock',
+    hungerCues:
+      'Rooting (turning head, opening mouth), sucking on fists or fingers, lip-smacking, increased alertness and squirming. Crying is a late cue — try to catch the earlier signals for calmer feeds.',
+    notes:
+      'Colostrum is produced for the first 2–3 days — it\'s thick, yellowish, and packed with antibodies. Transitional milk arrives around day 3–5, often with noticeable engorgement. The tiny volumes feel alarming but are exactly right for your baby\'s stomach, which is the size of a marble at birth.',
+  },
+  play: {
+    activities: [
+      'Skin-to-skin contact on your chest — regulates their temperature, breathing, and heart rate, and is the most powerful thing you can do right now',
+      'Slow, soft talking or singing during nappy changes — your voice is already their favourite sound in the world',
+      'Hold their gaze from 20–25 cm during alert moments — even a few seconds of eye contact is meaningful connection',
+      'Gentle swaddling and rocking — mimics the womb environment and is deeply comforting',
+    ],
+    bonding:
+      'Bonding in week 1 doesn\'t always feel like the movies. Many parents feel shock, exhaustion, protectiveness, or a quiet sense of unreality rather than instant overwhelming love. All of that is normal. Bonding is built through repetition — every feed, every nappy change, every time you respond to their cry. You are already doing it.',
+  },
+  parentTips: {
+    selfCare: [
+      'Sleep deprivation this week is extreme. Sleep in shifts if you have a partner — no one needs to be awake simultaneously for every night feed.',
+      'Accept every offer of practical help: meals brought to you, laundry done, older children entertained. You cannot recover and care for a newborn alone.',
+      'Your own physical recovery matters. Whether you had a vaginal birth or a caesarean, your body has been through something major. Rest is not optional.',
+    ],
+    watchFor: [
+      'Baby\'s stool transitioning from black meconium to greenish-brown to yellow within the first few days — this shows feeding is working',
+      'At least 1–2 wet nappies on day 1, rising to 6+ by day 5–6 — a reliable sign of adequate intake',
+      'Any alert window where baby briefly focuses on your face — this is early social awareness beginning',
+    ],
+    callDoctor: [
+      'Fever above 38°C / 100.4°F — always an emergency in the first 3 months, call immediately',
+      'Jaundice (yellowing of skin or whites of eyes) appearing before 24 hours or worsening rapidly after day 5',
+      'Fewer than 1 wet nappy in the first 24 hours, or fewer than 6 by day 5–6',
+      'Baby not latching or feeding after multiple attempts, or you are in significant pain with every feed — call a lactation consultant same day',
+    ],
+  },
+  dailyFacts: [
+    'Your baby\'s stomach on day 1 is roughly the size of a marble — about 5–7 ml capacity. Colostrum amounts that feel tiny are actually a perfect match.', // Day 1
+    'The black, tarry stool (meconium) your baby passes in the first day or two is made of amniotic fluid, mucus, and skin cells swallowed in the womb. It has almost no smell and clears within 48–72 hours.', // Day 2
+    'Day 3 is often the hardest for feeding. Milk is coming in, nipples are sensitive, and everyone is exhausted. If breastfeeding is painful or confusing, asking for help today is not giving up — it\'s the smart move.', // Day 3
+    'Jaundice peaks around day 3–5 in most babies and is caused by the breakdown of extra red blood cells present at birth. Mild jaundice is very common — but if your baby is very yellow, sleepy, or not feeding, get them checked.', // Day 4
+    'Your baby\'s weight loss bottoms out around day 3–4 (up to 10% of birth weight is normal). From here, with good feeding, they begin to gain. Most regain birth weight by 10–14 days.', // Day 5
+    'Newborns sleep in 45–60 minute sleep cycles and often wake briefly between cycles. The stirring you hear on the monitor may not be waking — give them 60 seconds before responding to see if they resettle.', // Day 6
+    'The umbilical cord stump should be kept clean and dry. Fold nappy waistbands down below it. No baths yet — sponge washing only until it falls off, which takes 1–3 weeks.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-02.js
+++ b/src/data/weeks/week-02.js
@@ -1,15 +1,77 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week02 = {
   week: 2,
-  ageRange: '2 weeks old',
-  title: 'Week 2 — 2 weeks old',
+  ageRange: '1–2 weeks old',
+  title: 'Week 2 — Finding a rhythm',
+  highlight:
+    'The fog is still thick, but something is shifting. Your baby is more alert between sleeps, feeding is becoming slightly more predictable, and you\'re starting to read each other — slowly, imperfectly, and that\'s exactly right.',
   illustration: '/illustrations/baby-02.png',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  physical: {
+    size: '~2.7–4.1 kg / 6–9 lbs — regaining birth weight, expect 20–30 g / 0.7–1 oz gain per day once feeding is established',
+    motorSkills:
+      'Still entirely reflex-driven, but you\'ll notice slightly more sustained periods of quiet alertness. Limbs remain jerky and uncoordinated. Head control is essentially zero — always support the head. Some babies briefly lift their chin off a surface when placed on their tummy.',
+    reflexes:
+      'All newborn reflexes remain strong. You may notice the rooting reflex triggering even when not hungry — this is normal. The grasp reflex is powerful enough that baby will grip your finger tightly when it\'s placed in their palm.',
+  },
+  cognitive: {
+    vision:
+      'Still focused best at 20–30 cm. Your baby is beginning to track very slow-moving objects through a tiny arc — a few centimetres at most. Faces remain the most captivating visual stimulus. High-contrast black and white patterns hold attention longer than colour.',
+    hearing:
+      'Already showing a preference for familiar voices over strangers\'. Voices heard regularly in the womb — yours, your partner\'s — are measurably more calming than unfamiliar ones. Your baby may briefly pause or still when they hear you speak.',
+    awareness:
+      'Alert windows are growing slightly — from a few minutes at a time to perhaps 10–20 minutes total across the day. During these moments, baby is genuinely taking in sensory information. Overstimulation is easy at this age — watch for looking away, arching, or fussing as cues to slow down.',
+  },
+  sleep: {
+    totalHours: '16–18 hours/day',
+    nightSleep: 'Still waking every 2–3 hours — no consolidated stretches yet for most babies',
+    naps: 'Many short naps with no predictable pattern — wake windows are still only 45–60 minutes',
+    notes:
+      'You may start noticing a very slight difference between day and night behaviour this week — some babies begin to have slightly longer stretches at night. This is circadian rhythm development just beginning, not a reliable pattern yet. Don\'t try to enforce a schedule — follow your baby\'s cues.',
+  },
+  feeding: {
+    amount: '30–60 ml (1–2 oz) per feed if bottle-feeding as transitional milk establishes; breastfed amounts vary but frequency confirms intake',
+    frequency: 'Every 2–3 hours, 8–12 feeds per day — cluster feeding in the evenings is normal and does not mean low supply',
+    hungerCues:
+      'Rooting, sucking movements, hand-to-mouth, increasing agitation. A baby who is calm and rooting is easier to latch than one already crying. Crying is hunger speaking its last resort — catch it earlier.',
+    notes:
+      'Breast milk is now fully transitioning from colostrum to mature milk. Engorgement — hard, swollen, tender breasts — is common around days 3–5 and may still be resolving this week. Feeding frequently is the best relief. The first growth spurt often hits around day 7–10 — expect a day or two of increased feeding frequency that can feel relentless.',
+  },
+  play: {
+    activities: [
+      'Tummy time on your chest while you\'re reclined — gravity is gentler and baby often tolerates it better than floor tummy time',
+      'Hold a black-and-white striped card or your face 20–25 cm away and move it very slowly — watch their eyes try to track',
+      'Narrate your day in a calm, warm voice during nappy changes and feeds — language exposure starts now, even if they understand nothing',
+      'Gentle baby massage after a bath — long slow strokes on arms and legs can be deeply calming for some babies',
+    ],
+    bonding:
+      'Week 2 bonding often feels less urgent than week 1 and more like a slow accumulation. You\'re learning your baby\'s sounds — which cry means hungry, which means overtired, which means something hurts. This pattern recognition is the foundation of attachment. Trust your growing instincts, even when they feel uncertain.',
+  },
+  parentTips: {
+    selfCare: [
+      'Newborn rashes are common and alarming-looking. Erythema toxicum — blotchy red patches with pale or yellow centres — appears in around half of all newborns and is completely harmless, resolving on its own within days.',
+      'If you\'re breastfeeding, book a lactation consultant check-in this week if anything feels off. Early problems compound quickly — early help resolves them.',
+      'The 2-week midwife or health visitor check is usually this week. Write down any questions before you go — you\'ll forget half of them in the room.',
+    ],
+    watchFor: [
+      'Birth weight regained or clearly trending upward by the end of this week',
+      'More defined alert periods — eyes open, looking around, responding to your voice',
+      'First reflexive smile — a fleeting, involuntary twitch at the corners of the mouth, usually during sleep or drowsiness. It\'s not social yet, but it\'s wonderful.',
+    ],
+    callDoctor: [
+      'Fever above 38°C / 100.4°F — always a same-day call in the first 3 months',
+      'Jaundice persisting or worsening after day 7, or baby is very sleepy and hard to rouse for feeds',
+      'Fewer than 6 wet nappies per day — a reliable early sign of inadequate intake',
+      'Umbilical cord stump showing redness spreading to the surrounding skin, foul smell, or oozing — these can signal infection',
+    ],
+  },
+  dailyFacts: [
+    'Baby acne — small whiteheads or red spots on the face — can appear this week and over the next few weeks. It\'s caused by maternal hormones still circulating in your baby\'s system and clears on its own. No treatment needed.', // Day 1 (day 8)
+    'Your baby\'s first social smile won\'t come until around 6 weeks, but the reflexive "sleep smile" you see now — a fleeting twitch during drowsiness or light sleep — is still a real dopamine hit. Enjoy it.', // Day 2 (day 9)
+    'The first growth spurt often arrives around day 7–10. If your baby suddenly wants to feed constantly for 24–48 hours, this is almost certainly why. Follow their lead — supply responds to demand, and this phase passes.', // Day 3 (day 10)
+    'Most breastfed babies regain their birth weight by day 10–14. Formula-fed babies typically reach it a few days earlier. If your baby\'s weight check is coming up, feeding frequently in the days before gives the best chance of a good result.', // Day 4 (day 11)
+    'Newborns breathe irregularly — fast breaths, slow breaths, occasional pauses of up to 10 seconds. This periodic breathing is normal. Breathing that stops for longer than 20 seconds, or is accompanied by colour change, warrants immediate attention.', // Day 5 (day 12)
+    'Your baby is starting to associate your smell with comfort and food. Studies show newborns can identify their primary caregiver\'s scent within days of birth. When nothing else helps, sometimes just being close to you is enough.', // Day 6 (day 13)
+    'Alert windows are still short — 20 to 45 minutes before tiredness kicks in. Overstimulation at this age leads to crying and difficulty settling. When in doubt, a dark, quiet room and gentle holding resets most unsettled babies faster than engagement.', // Day 7 (day 14)
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-03.js
+++ b/src/data/weeks/week-03.js
@@ -1,15 +1,77 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week03 = {
   week: 3,
-  ageRange: '3 weeks old',
-  title: 'Week 3 — 3 weeks old',
+  ageRange: '2–3 weeks old',
+  title: 'Week 3 — The hardest week',
+  highlight:
+    'Week 3 is when many parents hit a wall. The growth spurt arrives, cluster feeding begins, and the cumulative exhaustion is real. Hold on — you\'re not doing it wrong. This is simply the hardest part of the newborn period.',
   illustration: '/illustrations/baby-03.png',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  physical: {
+    size: '~3.0–4.5 kg / 6.5–10 lbs — gaining approximately 150–200 g / 5–7 oz per week during the growth spurt',
+    motorSkills:
+      'Still reflex-driven, but movements are becoming very slightly smoother. During tummy time, some babies can briefly lift the chin off the surface for a second or two. Legs push against surfaces when held upright — the stepping reflex feels stronger as legs grow. Fists remain mostly clenched.',
+    reflexes:
+      'All primitive reflexes remain strong and healthy. The Moro startle reflex can be triggered by your own movements when holding baby — a swaddle helps reduce this. Sucking reflex is becoming more coordinated as feeding practice accumulates.',
+  },
+  cognitive: {
+    vision:
+      'Tracking is improving noticeably — your baby can now follow a slow-moving face or object through a 90-degree arc in good conditions. Prefers faces above all other stimuli. Beginning to stare intently at high-contrast objects held in their visual range. Colour vision is developing but still muted.',
+    hearing:
+      'Turning toward familiar voices is more consistent this week. Your baby may quiet or pause when they hear you from across the room — a clear sign of recognition. Responds differently to soothing versus stimulating sounds.',
+    awareness:
+      'Genuine social interaction is beginning. Your baby will sometimes hold your gaze and still in response to your face and voice — this is not accidental. Some babies show their first true social smile around 3 weeks, though most arrive closer to 6 weeks. Either way, connection is happening.',
+  },
+  sleep: {
+    totalHours: '15–18 hours/day',
+    nightSleep: 'Waking every 2–3 hours — some babies begin to show one slightly longer stretch of 3–4 hours at night',
+    naps: 'Multiple short naps; wake windows still 45–75 minutes before overtiredness sets in',
+    notes:
+      'The growth spurt disrupts whatever loose rhythm may have been emerging. This is temporary — usually 2–4 days of increased feeding and disrupted sleep before things settle again. The crying peak that often begins around week 3 can make nights especially hard. Try to tag-team with a partner or support person if at all possible.',
+  },
+  feeding: {
+    amount: '60–90 ml (2–3 oz) per feed if bottle-feeding; breastfed babies feed more frequently during cluster feeding periods',
+    frequency: 'Every 2–3 hours, but cluster feeding evenings (every 30–60 minutes for 3–4 hours) is normal and hunger-driven',
+    hungerCues:
+      'Rooting, sucking, fist-to-mouth, increased alertness and fussing. During cluster feeding, your baby may seem insatiable — this is real hunger driving a supply increase, not a sign that you\'re not producing enough.',
+    notes:
+      'Cluster feeding in the evenings — when your baby seems to want to feed almost continuously for hours — is one of the most exhausting features of week 3. It is not a sign of low milk supply. It is your baby\'s way of boosting supply ahead of the growth spurt, and it works. The payoff typically comes within a few days.',
+  },
+  play: {
+    activities: [
+      'Face-to-face time during alert windows — hold your face 25 cm away, move slowly, talk or sing softly, and watch them track you',
+      'Short tummy time sessions on a firm surface, 2–3 minutes at a time, 2–3 times a day — support is fine, consistency matters more than duration',
+      'Gentle swaying or baby-wearing during fussy cluster feeding evenings — movement soothes, and having your hands free helps you survive',
+      'Read aloud from anything — your phone, a book, whatever is in front of you. Your voice is the content, not the words.',
+    ],
+    bonding:
+      'By week 3, you are learning this specific baby — not babies in general, but this one, with their particular sounds and patterns. That knowledge is real and hard-won. The moments of genuine eye contact that are beginning this week are early reciprocal communication. Your baby is not just receiving care — they are beginning to respond to you.',
+  },
+  parentTips: {
+    selfCare: [
+      'If you\'re feeling overwhelmed, tearful, angry, or numb beyond normal tiredness, please tell someone. Postnatal depression and anxiety can emerge at any point in the first year. Week 3 is a common time for it to surface — you are not alone and it is treatable.',
+      'The umbilical cord stump should have fallen off by now or within the next few days. If it hasn\'t, that\'s fine — the normal range extends to 3 weeks. Once it\'s off, you can give baby their first proper bath.',
+      'Lower the bar for everything that isn\'t keeping your baby fed and safe. Unwashed dishes and unanswered messages are a correct response to week 3 of parenthood.',
+    ],
+    watchFor: [
+      'Brief but genuine eye contact during calm alert moments — your baby looking at your face and stilling is early social connection',
+      'Head lifting briefly during tummy time — even a second or two is progress',
+      'Slightly longer sleep stretch appearing at night — even 3 hours in a row is a meaningful shift at this age',
+    ],
+    callDoctor: [
+      'Fever above 38°C / 100.4°F — always call immediately in the first 3 months, no exceptions',
+      'Crying that is inconsolable for more than 2–3 hours, especially if high-pitched or clearly different from usual cry',
+      'Umbilical cord stump showing spreading redness, swelling, foul smell, or pus — signs of omphalitis (cord infection), which needs same-day assessment',
+      'Any concern that your baby is not gaining weight, has fewer than 6 wet nappies per day, or seems persistently lethargic and hard to wake for feeds',
+    ],
+  },
+  dailyFacts: [
+    'The 3-week growth spurt typically hits between days 17–21. Your baby\'s appetite surging and sleep disrupting for a few days is the mechanism, not a problem. Increased feeding drives increased supply, and within 3–4 days things usually settle.', // Day 1 (day 15)
+    'Crying typically peaks between weeks 3 and 6 in healthy babies — this is sometimes called the "normal fussy period" or, if very intense, the "period of PURPLE crying." It is not caused by anything you\'re doing wrong. It is a developmental phase.', // Day 2 (day 16)
+    'Your baby may now briefly follow your face as you move across their field of vision. This is not accidental — it\'s the visual cortex and attention systems developing together. Slow movements work best; quick ones are too fast to track.', // Day 3 (day 17)
+    'Cluster feeding evenings feel relentless because they are. Many parents find the 5–9 pm window the hardest of the entire day. Tag-teaming feeds, baby-wearing, and a podcast in your ears are all legitimate survival tools.', // Day 4 (day 18)
+    'Some babies show their first genuine social smile as early as 3 weeks — a real, wide smile in response to your face or voice, not during sleep. Most won\'t smile socially until 6 weeks, so don\'t worry if it hasn\'t happened yet.', // Day 5 (day 19)
+    'Baby\'s digestive system is maturing, which can cause visible straining, grunting, and red-faced effort even with soft stools. This is called "grunting baby syndrome" and is very common at 3–4 weeks. If stools remain soft, it\'s not constipation.', // Day 6 (day 20)
+    'By the end of week 3, most parents have developed a working knowledge of their baby\'s cries, preferences, and patterns — even if it doesn\'t feel that way. This knowledge is real, even when you\'re too tired to trust it. You know more than you think.', // Day 7 (day 21)
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-04.js
+++ b/src/data/weeks/week-04.js
@@ -64,5 +64,14 @@ export const week04 = {
       'Difficulty latching, painful feeds, or signs baby isn\'t gaining weight',
     ],
   },
+  dailyFacts: [
+    'Your baby sees best at 20–30 cm — the exact distance between your face and theirs during a feed. Every nursing or bottle session is also a vision workout.',
+    'One month old today, in a sense. The Moro startle reflex — that full-body flinch at sudden sounds — is a sign of a perfectly healthy nervous system, not a sign your baby is anxious.',
+    'Tummy time for even 60 seconds at a stretch builds the neck and shoulder strength your baby needs for every motor milestone ahead. It doesn\'t have to be long to be useful.',
+    'Your voice is your baby\'s favourite sound in the world — they\'ve been listening to it since before birth. Narrating your day out loud is one of the best things you can do for their developing brain.',
+    'The 4–6 week mark is often the peak of newborn exhaustion for parents. If today is hard, that\'s not a reflection of how you\'re doing — it\'s just where you are in the timeline.',
+    'Hands tightly fisted most of the time is completely normal at this age. Your baby isn\'t stressed — it\'s simply how newborn muscle tone works, and it will relax over the coming weeks.',
+    'The 6-week postpartum check-up is coming soon. Be fully honest with your doctor or midwife about how you\'re feeling — emotionally and physically. This appointment is for you, not just a formality.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-05.js
+++ b/src/data/weeks/week-05.js
@@ -64,5 +64,14 @@ export const week05 = {
       'Not feeding well or showing signs of dehydration',
     ],
   },
+  dailyFacts: [
+    'Week 5 is often the peak of fussiness — more crying, more cluster feeding, more need to be held. If today feels like the hardest yet, you\'re probably right. A corner is genuinely coming.',
+    'Cluster feeding in the evenings isn\'t a sign of low milk supply — it\'s your baby tanking up before a longer sleep stretch. Follow their lead and trust the process.',
+    'Responding to your baby every single time they cry is not spoiling them — it\'s building their brain. Every time you show up, they learn the world is safe. That security lasts a lifetime.',
+    'Your baby may be showing very early signs of soothing to a consistent sound or song. Repetition is how newborns learn — the same lullaby every night is never boring to them.',
+    'Those brief reflexive smiles during light sleep aren\'t social yet — but the real ones are only about a week away. Keep watching.',
+    'Skin-to-skin contact is still incredibly powerful at 5 weeks. Even 10 minutes with your baby\'s head on your bare chest helps regulate their heart rate, temperature, and stress hormones.',
+    'Postpartum mood changes can peak around weeks 4–6. Feeling overwhelmed is normal; feeling hopeless or unable to bond is a signal to reach out to your doctor — and help is very effective.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-06.js
+++ b/src/data/weeks/week-06.js
@@ -64,5 +64,14 @@ export const week06 = {
       'Feeding difficulties or poor weight gain',
     ],
   },
+  dailyFacts: [
+    'The first real social smile is imminent if it hasn\'t arrived yet — wide, gummy, aimed straight at your face. It will be unmistakable, and you\'ve absolutely earned it.',
+    'Your baby\'s alert periods are stretching to 1–1.5 hours. That\'s more time for real interaction — face-to-face "conversations," tummy time, and just being together awake.',
+    'The 6-week postpartum check-up is one of the most important appointments of the first year. Be honest with your provider about sleep, mood, pain, and how you\'re really coping.',
+    'Evening fussiness often peaks right around now. A consistent wind-down routine — walk, white noise, skin-to-skin — won\'t fix it instantly, but it gives you both something to anchor to.',
+    'Your baby is starting to distinguish your face from a stranger\'s with more reliability. You are becoming unmistakably "their person" in their developing brain.',
+    'Tummy time placed in front of a small mirror is surprisingly motivating at this age — the baby in the mirror is endlessly fascinating to them.',
+    'The 6-week fussiness peak usually starts to ease by weeks 8–10. If tonight is hard, you are genuinely closer to the corner than you were last week.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-07.js
+++ b/src/data/weeks/week-07.js
@@ -64,5 +64,14 @@ export const week07 = {
       'Signs of dehydration: no wet nappies for 8+ hours, dry mouth, no tears when crying',
     ],
   },
+  dailyFacts: [
+    'Social smiles are increasing this week — and each one is your baby\'s way of telling you they know you and they love you. Smile back every time; you\'re wiring their brain for connection.',
+    'Most 7-week-olds can only stay comfortably awake for 45–75 minutes before they need to sleep. Catching tired cues early — yawning, staring off, fussing — leads to much easier settling.',
+    'Your baby is starting to differentiate between your soothing voice and your playful voice. They\'re reading you more than you realise — and they like what they see.',
+    'Wearing your baby in a carrier during your normal day provides movement, warmth, and closeness — all deeply calming and stimulating at once. Your hands stay free; their brain stays happy.',
+    'The fading of newborn reflexes isn\'t something to worry about — it\'s a sign the brain is developing beautifully, with voluntary control taking over from automatic responses.',
+    'Introducing a bottle between weeks 4–8 (if you\'re breastfeeding and want that option later) is often recommended before nipple preference can set in. No pressure — just a window to know about.',
+    'Week 7 is often the first time parents feel like their baby genuinely "knows" them. That feeling is real. You are their whole world.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-08.js
+++ b/src/data/weeks/week-08.js
@@ -67,5 +67,14 @@ export const week08 = {
       'Seems limp, unusually still, or very difficult to wake',
     ],
   },
+  dailyFacts: [
+    'Two months old — and those big, gummy social smiles are here. When your baby grins at your face or voice, that\'s not reflex anymore. That\'s them choosing you.',
+    'The 2-month well-visit is likely this week, along with the first round of vaccinations. Your baby may be fussier and sleepier for a day or two after — that\'s a normal immune response.',
+    'Your baby can now track a slowly moving object through nearly 180°. Hold a colourful toy at 20–30 cm and move it slowly side to side — watch their eyes follow with real focus.',
+    'Bedtime routines can gently begin now — a simple sequence of bath, feed, and song helps their developing brain start to associate certain cues with sleep. It doesn\'t need to be rigid to be effective.',
+    'Skin-to-skin contact still regulates your baby\'s temperature, heart rate, and stress hormones — even at 8 weeks. A few minutes of bare chest contact each day is never wasted.',
+    'Sleep debt is real and cumulative. Even one protected 4–5 hour block of uninterrupted sleep per night — shared with a partner or support person — makes a measurable difference to how you function.',
+    'Cooing and soft vowel sounds ("ooh," "aah") are beginning or arriving this week. When you echo them back and pause, you\'re teaching your baby the basic rhythm of conversation.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-09.js
+++ b/src/data/weeks/week-09.js
@@ -62,5 +62,14 @@ export const week09 = {
       'Difficulty feeding, excessive vomiting, or poor weight gain',
     ],
   },
+  dailyFacts: [
+    'The hardest weeks of newborn sleep are likely behind you now. Variation is still normal — a rough night after a good one isn\'t a step backward, just the natural rhythm of this stage.',
+    'Your baby is starting to reach toward objects, though they won\'t always make contact yet. Dangling a colourful toy 20–30 cm above them gives their arms something to aim for.',
+    'When you coo and your baby coos back, you\'re not just playing — you\'re literally wiring the social, language, and emotional centres of their developing brain. Presence and responsiveness are everything.',
+    'Shorter breastfeeding sessions don\'t mean less milk — your baby is simply getting more efficient. Watch nappy output and weight gain rather than the clock.',
+    'Carrying your baby facing outward in a carrier gives them an upright, stimulating view of the world while keeping them close and regulated. It\'s rich input without being overwhelming.',
+    'Your baby is beginning to show excitement when a favourite person approaches — that wiggle and brighten when they see your face is one of the most rewarding things you\'ll experience this month.',
+    'If things are starting to feel more manageable this week, that\'s real — not a trick. Accept it and enjoy it. You\'ve earned this shift.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-10.js
+++ b/src/data/weeks/week-10.js
@@ -62,5 +62,14 @@ export const week10 = {
       'No social smiling by this week — mention at next visit',
     ],
   },
+  dailyFacts: [
+    'Your baby now notices things across the room — a complete change from the 20–30 cm newborn range. Their visual world is expanding rapidly, and so is their curiosity.',
+    'Smiles are freely given to multiple caregivers now, not just you. Watching your baby charm everyone they meet is one of the genuine joys of this age.',
+    'Simple peekaboo — hiding your face and revealing it — is genuinely stimulating at 10 weeks. It hints at object permanence, the idea that things still exist when they can\'t be seen.',
+    'A 3-month growth spurt is approaching in the next few weeks. If your baby suddenly seems insatiable for a few days, feed on demand — it will pass within 48–72 hours.',
+    'Narrating your day as you go — nappy changes, making coffee, walking to the shops — floods your baby\'s brain with language input. Every word you say is a seed planted.',
+    'Ten weeks in, you\'ve built real intuition about your baby — their cries, their rhythms, their tells. That knowledge is hard-won and genuinely yours. Trust it.',
+    'Some babies are sleeping 5–6 hours at night by now; others are not. Both are within the normal range. Comparing to other babies will only stress you — follow your own.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-11.js
+++ b/src/data/weeks/week-11.js
@@ -62,5 +62,14 @@ export const week11 = {
       'No social smiling, no interactive response',
     ],
   },
+  dailyFacts: [
+    'The first laugh could arrive any day now. It tends to come during a moment of joyful interaction — a funny noise, a gentle tickle, an exaggerated expression. Stay ready.',
+    'When your baby discovers that kicking the gym mobile makes it move, watch for the pause, the look, and the deliberate second kick. That\'s cause-and-effect understanding happening in real time.',
+    'Head control is noticeably stronger this week — your baby can hold their head in line with their body when gently pulled to sit. That growing neck strength is doing a lot of work.',
+    'Parentese — the high-pitched, exaggerated, sing-song voice most people naturally use with babies — is literally optimised for infant learning. Don\'t be embarrassed to use it freely.',
+    'A growth spurt is common around weeks 11–13. If your baby seems constantly hungry for a few days, feed on demand and know it won\'t last.',
+    'Loose nap patterns may start to emerge this week. Don\'t force a schedule — just watch wake windows of around 75–90 minutes and respond to tiredness cues before they escalate.',
+    'If you\'re starting to feel more like yourself this week, honour that by doing one small thing today that feels like "you" — a walk, a call to a friend, something that isn\'t about the baby.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-12.js
+++ b/src/data/weeks/week-12.js
@@ -66,5 +66,14 @@ export const week12 = {
       'Persistent fever above 38°C / 100.4°F',
     ],
   },
+  dailyFacts: [
+    'Three months — and the newborn fog is lifting. Your baby is laughing, "talking" back to you, and discovering their hands with wide-eyed wonder. This is one of the most rewarding weeks yet.',
+    'Most primitive reflexes — the Moro startle, the rooting, the stepping — are fading now. That\'s not a loss; it\'s the brain maturing. Voluntary, intentional movement is taking their place.',
+    'The 4-month sleep regression is still a few weeks away, but knowing it\'s coming helps. A consistent wind-down routine now — bath, feed, song — builds the association that will serve you both well.',
+    'Breastfed babies at 3 months are very efficient feeders — a 5–7 minute session can be just as satisfying as a 20-minute newborn feed. Short doesn\'t mean insufficient.',
+    'Postpartum depression can emerge or worsen around the 3-month mark, not just immediately after birth. Check in honestly with yourself — effective help is available at any stage.',
+    'Reading board books aloud at 3 months isn\'t about comprehension — it\'s about the rhythm, tone, and music of your voice. The habit you build now will matter greatly later.',
+    'If parental leave is ending around now, that transition is emotionally complex — grief and relief can coexist. Both are valid. Give yourself grace for whatever you\'re feeling.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-13.js
+++ b/src/data/weeks/week-13.js
@@ -62,5 +62,14 @@ export const week13 = {
       'Head still very floppy — poor head control when supported upright',
     ],
   },
+  dailyFacts: [
+    'Your baby is in their social golden age right now — freely laughing, grinning, and delighting in every interaction. Lean into it. This is genuinely one of the most enjoyable stretches of the whole first year.',
+    'Rolling from tummy to back is happening with increasing frequency this week. Once they can do it, supervised floor time on a safe surface becomes their favourite way to explore.',
+    'Your baby can now see and react to objects across the room — a button on your shirt, a light on the ceiling. Their visual curiosity is picking up detail you\'d never expect them to notice.',
+    'Object permanence is just starting to develop — your baby may look briefly for a dropped toy. It\'s a tiny moment, but it\'s a significant cognitive leap from just a few weeks ago.',
+    'Longer night stretches may be appearing now — this is the calm before the 4-month sleep regression. Enjoy it, and mentally prepare for some disruption in the coming weeks.',
+    'Your baby is expressing distinct emotional states now: excitement, contentment, frustration, boredom. Reading those states and responding to them is the work of early parenting — and you\'re doing it.',
+    'Three months of knowing each other. You know their sounds, their rhythms, their faces. They light up when they see you. The bond built in this short time is their first and most important relationship.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-14.js
+++ b/src/data/weeks/week-14.js
@@ -62,5 +62,14 @@ export const week14 = {
       'Seems to have lost skills they previously had — always worth a call',
     ],
   },
+  dailyFacts: [
+    'Hand regard — your baby staring intensely at their own hands — is completely normal and actually brilliant. They\'re discovering that those wiggly things belong to them and respond to their intentions.',
+    'The 4-month sleep regression may be arriving or just around the corner. More night waking after good nights is a common first sign — it\'s not a step backward, it\'s biology.',
+    'Your baby can push up on extended arms during tummy time now, briefly lifting their chest off the surface. That\'s a significant strength milestone that sets the stage for crawling.',
+    'Distracted feeding is picking up this week — your baby is so interested in the world that they keep pulling off to look around. Try feeding in a quieter, dimmer room.',
+    'Curiosity about your food is developmentally normal at this age, but it\'s not a readiness sign for solids on its own. The recommendation is to wait until 6 months and look for several signs together.',
+    'Stranger awareness is beginning — your baby may stare solemnly at unfamiliar people. This is a cognitive milestone, not shyness; they\'re distinguishing familiar from unfamiliar.',
+    'Sleep regression is harder on parents who had a taste of good sleep. Be kind to yourself if tonight feels like you\'re back at the start — you\'re not. You have knowledge and tools you didn\'t have before.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-15.js
+++ b/src/data/weeks/week-15.js
@@ -61,5 +61,14 @@ export const week15 = {
       'Persistent one-sided movements or preference for turning head one way only',
     ],
   },
+  dailyFacts: [
+    'Your baby grabbing their own feet and giggling is a moment of profound self-discovery — they\'re learning the edges of themselves, where they end and the world begins. Watch it with your full attention.',
+    'The 4-month regression tends to peak around weeks 14–16. If nights are harder than they were a few weeks ago, this is almost certainly why — and most families see improvement by weeks 18–20.',
+    'Passing objects between hands is beginning to emerge. It\'s clumsy and inconsistent, but it\'s the first hint of the hand coordination that will develop rapidly over the coming months.',
+    'Your baby is starting to recognise frequently heard words — "milk," "bath," "nappy," their own name. They won\'t respond consistently yet, but the neural pathways are forming.',
+    'Simple predictable sequences (bath time means bedtime is coming) are starting to be understood. Consistency in your routine now pays dividends in settling and security.',
+    'Free floor time with no specific goal — just a safe blanket, freedom to move, and you nearby — is some of the best "play" at this age. Your baby\'s curiosity is the curriculum.',
+    'You\'re almost at 4 months — one of the most significant milestones of the first year. Things are genuinely about to get even more fun.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-16.js
+++ b/src/data/weeks/week-16.js
@@ -66,5 +66,14 @@ export const week16 = {
       'Not showing interest in faces or people around them',
     ],
   },
+  dailyFacts: [
+    'Four months old — and your baby is unmistakably themselves. They have favourite people, favourite songs, favourite games. When they reach for you, they know exactly who you are and why they want you.',
+    'The 4-month sleep regression is happening because your baby\'s sleep has reorganised into adult-like cycles. They now wake briefly between cycles but haven\'t learned to resettle — it\'s developmental, not a problem you created.',
+    'Near-adult colour vision is established by 4 months. Your baby can see the full colour spectrum and is showing clear preferences for certain colours, patterns, and toys.',
+    'Blowing raspberries back and forth is more than silly fun — imitation games at this age are directly building the social and language circuits your baby will rely on for life.',
+    'Object permanence is beginning — your baby may look briefly for a toy you\'ve hidden. This is a major cognitive leap: things still exist even when they can\'t be seen.',
+    'If you\'re pumping and returning to work, now is a good time to reassess your feeding plan with a lactation consultant if anything isn\'t working. It\'s not too late to adjust.',
+    'Sixteen weeks in — your nervous system has been in a state of high alert since birth. Rest when you can, eat real food, and let go of things that don\'t matter. You\'ve been doing something extraordinary.',
+  ],
   isStub: false,
 }

--- a/src/data/weeks/week-17.js
+++ b/src/data/weeks/week-17.js
@@ -3,12 +3,77 @@ export const week17 = {
   week: 17,
   ageRange: '4 months old',
   title: 'Week 17 — 4 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  highlight:
+    'The 4-month sleep regression is still very much a thing, but the daytime version of your baby is getting more exciting by the day — deliberate reaching, full-room smiles, and hands permanently stuffed in their mouth.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.2–7.2 kg / 13.5–16 lbs, ~63–66 cm / 25–26 in',
+    motorSkills:
+      'Rolling tummy-to-back is becoming more reliable and consistent — many babies can do it on purpose now rather than by accident. Deliberate reaching is solidifying: your baby spots something they want and goes for it with real intention. Head control is excellent. Tummy time is longer and more comfortable as arm strength builds. Hands are almost constantly in the mouth — this is completely normal and not a teething sign yet.',
+    reflexes:
+      'Primitive newborn reflexes are fully gone. All movements are purposeful and voluntary. The startle (Moro) reflex has faded, so your baby no longer throws their arms wide at sudden sounds — a big step toward calmer sleep transitions.',
+  },
+  cognitive: {
+    vision:
+      'Near-adult colour perception is established. Your baby tracks moving objects across their entire visual arc without losing them. They spot familiar faces across a room and light up immediately. Visual interest in small details — patterns on clothing, a print on the wall — is increasing.',
+    hearing:
+      'Turns quickly and accurately toward voices and sounds. Responds to their own name with a pause and look of recognition. Music remains a powerful tool — upbeat songs prompt excited wiggling, and slow songs genuinely calm them.',
+    awareness:
+      'Face-to-face interaction is the highlight of your baby\'s day. They study your expressions closely and mirror them. Early cause-and-effect understanding is building: they are starting to realise that their actions (like kicking a toy) produce results. Social smiling is rich and generous with familiar people.',
+  },
+  sleep: {
+    totalHours: '12–15 hours/day',
+    nightSleep: 'Often 4–6 hour first stretch, then 2–3 hour chunks — regression may still be disrupting things',
+    naps: '3–4 naps, typically a longer morning nap of 1–1.5 hours and shorter afternoon catnaps',
+    notes:
+      'The 4-month sleep regression usually peaks between weeks 16 and 18, so you may still be in the thick of it. Night wakings that had settled may have returned. This is not a feeding problem or a hunger issue — it\'s neurological. Your baby\'s sleep architecture has permanently changed to adult-like cycles, and they haven\'t yet mastered linking those cycles independently. Hang in there: most families see improvement by weeks 19–20.',
+  },
+  feeding: {
+    amount: '120–180 ml (4–6 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–7 feeds per day',
+    hungerCues:
+      'Rooting, mouthing hands, increased fussiness, turning head side to side. Distracted feeding is common now — your baby is too interested in the world to focus. Try feeding in a dim, quiet room if they keep pulling off.',
+    notes:
+      'Solid foods are still not recommended. If someone in your life is suggesting rice cereal or purees at 4 months, the current guidance from major paediatric organisations is to wait until 6 months (or at minimum 4 months and with clear readiness signs). Breast milk or formula meets all nutritional needs for now.',
+  },
+  play: {
+    activities: [
+      'Shake-and-grab: offer a light rattle or soft toy and watch them reach for it — then shake it near their hand to encourage grasping',
+      'Mirror time: hold your baby in front of a baby-safe mirror and watch them study the "other baby" with fascination',
+      'Tummy time with a prop: roll a small towel under their chest during tummy time to take some pressure off and extend how long they\'ll tolerate it',
+      'Copying game: stick out your tongue, raise your eyebrows, open your mouth wide — they\'re still learning to mirror you and it\'s endlessly entertaining',
+      'Sensory textures: let them feel different fabrics, a cool wooden toy, a soft cloth book — their hands are their primary explorer right now',
+    ],
+    bonding:
+      'This week, lean into being your baby\'s favourite comedian. They laugh at surprising things — a funny sound, a sudden expression change, being lifted overhead. When you find what makes them belly-laugh, repeat it shamelessly. These shared joy moments are building the secure attachment that underpins everything in their development. You are their safe base from which they explore the world.',
+  },
+  parentTips: {
+    selfCare: [
+      'If you\'re still in the regression and running on low sleep, this is the week to call in a favour. Ask a partner, family member, or friend to take a shift so you can sleep more than 4 hours in a row — even once.',
+      'Notice if you\'re comparing your baby\'s sleep to someone else\'s. Sleep at this age is enormously variable. A baby sleeping 8-hour stretches at 4 months is the exception, not the rule.',
+      'Your 4-month check-up may be this week or coming up soon. Write down your questions beforehand — feeding, sleep, development — so you don\'t forget anything in the room.',
+    ],
+    watchFor: [
+      'Reliable tummy-to-back rolling — doing it intentionally rather than accidentally',
+      'Deliberate reaching for toys and bringing objects to the mouth',
+      'Rich social smiling and laughter with familiar people',
+      'Responding to their own name with recognition',
+    ],
+    callDoctor: [
+      'Not reaching for or grasping objects by 4 months',
+      'No social smiling or laughter by this point',
+      'Not tracking objects with eyes across their visual field',
+      'Seems stiff, floppy, or has noticeably asymmetric movement',
+    ],
+  },
+  dailyFacts: [
+    'Your baby\'s drooling right now is not caused by teething — it\'s because their salivary glands have matured and they haven\'t yet learned to swallow the extra saliva. Actual teething usually starts closer to 6 months.',
+    'When your baby stares at your face during a feed and then breaks into a smile, they\'re practising "social referencing" — checking in with you emotionally. It\'s an early form of communication.',
+    'The 4-month sleep regression is one of the most well-documented sleep disruptions in infancy. It happens because your baby\'s brain has literally reorganised how it sleeps — from newborn sleep stages to adult-like cycles. It\'s a sign of healthy neurological development.',
+    'Tummy time resistance often fades dramatically around this age as neck and shoulder muscles get stronger. If your baby still protests, try placing them on your chest or over your legs rather than the floor.',
+    'Your baby\'s reaching is becoming hand-specific — many babies start showing a slight preference for one hand around 4 months, though true handedness won\'t be established for years.',
+    'Babies this age love contrast and movement. A mobile or hanging toy above their play mat isn\'t just entertainment — it\'s genuine visual and cognitive exercise.',
+    'If your baby seems to have more wakeful periods at night lately but is happy and developing well during the day, they are almost certainly going through the regression rather than being unwell. Regression babies are tired, not sick.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-18.js
+++ b/src/data/weeks/week-18.js
@@ -3,12 +3,76 @@ export const week18 = {
   week: 18,
   ageRange: '4 months old',
   title: 'Week 18 — 4 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  highlight:
+    'Sleep may be starting to stabilise after the regression, and your baby\'s communication is levelling up — those simple coos are turning into something that sounds almost like syllables. A real conversation is beginning.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.3–7.4 kg / 14–16.5 lbs, ~63–67 cm / 25–26.5 in',
+    motorSkills:
+      'Rolling tummy-to-back is becoming genuinely reliable for most babies. Some adventurous ones are beginning to attempt back-to-tummy — they rock onto their side and strain to get over, which looks very effortful and is excellent strength work. When placed in a sitting position with your hands supporting their trunk, they hold themselves upright for short periods. They can hold a rattle placed in their hand and shake it with growing intention.',
+    reflexes:
+      'Hand-to-mouth movement is beautifully coordinated now — your baby can guide their fist or a toy to their mouth with real accuracy. Leg movements during tummy time may start looking like early crawling attempts as hip and core strength builds, though actual crawling is months away.',
+  },
+  cognitive: {
+    vision:
+      'Visual tracking is smooth across the full arc — horizontal, vertical, and circular. Your baby follows a moving toy without jerking or losing it. Depth perception continues to improve. They are increasingly fascinated by small details: buttons, patterns on fabric, the movement of leaves through a window.',
+    hearing:
+      'Locates sounds accurately, turning their head in the correct direction quickly. Recognises caregivers\' voices from across the room and responds with increased alertness or a smile. Beginning to distinguish emotional tone — a tense voice versus a playful one produces visibly different reactions.',
+    awareness:
+      'Object permanence is emerging: if you hide a toy under a cloth slowly, your baby may look for it briefly. Recognises familiar caregivers and reacts more cautiously to strangers — not yet with anxiety, but with a careful, assessing look. Early cause-and-effect understanding is growing: they are learning that actions have predictable outcomes.',
+  },
+  sleep: {
+    totalHours: '12–15 hours/day',
+    nightSleep: 'Beginning to improve for many families — first stretch of 5–7 hours returning for some',
+    naps: '3–4 naps, with morning nap often the longest at 1–2 hours',
+    notes:
+      'For many babies, week 18 marks the tail end of the 4-month sleep regression. You may start seeing longer first stretches at night returning, and naps becoming slightly more predictable. If things are still rough, hold on — the regression rarely lasts past weeks 19–20. If you\'re ready to try gentle sleep shaping (consistent pre-nap routines, putting down drowsy but awake), now is a reasonable time to start.',
+  },
+  feeding: {
+    amount: '120–180 ml (4–6 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–7 feeds per day',
+    hungerCues:
+      'Rooting, mouthing fists, fidgeting and fussing before escalating to crying. Your baby is getting better at signalling hunger earlier — reading their subtle early cues makes feeds calmer for everyone.',
+    notes:
+      'Breastfed babies may have a notable cluster feeding session in the evening — this is normal and does not mean your supply is low. It\'s often as much a comfort and bonding behaviour as a nutritional one. Formula-fed babies may begin stretching slightly longer between feeds as stomach capacity grows.',
+  },
+  play: {
+    activities: [
+      'Rattle exploration: place different rattles and shakers in their hand — they\'re learning that their arm movements cause sounds, which is genuinely thrilling to a 4-month-old',
+      'Vocal tennis: when your baby coos or makes a sound, respond with a similar sound, then pause and wait. They will often "answer" you — this back-and-forth is the foundation of language.',
+      'Visual tracking: slowly move a brightly coloured toy in a figure-eight pattern in front of them and watch their eyes follow smoothly across the full arc',
+      'Supported sitting on your lap facing outward — they love seeing the world from an upright perspective and surveying the full room',
+    ],
+    bonding:
+      'Your baby is starting to respond to your mood in a deeper way this week. If you\'re stressed, they sense it. If you\'re laughing, they\'re more likely to laugh too. This isn\'t pressure — it\'s connection. Taking a breath and being fully present, even for a 5-minute floor session, is more valuable than you might think. The quality of attention matters more than the quantity of time.',
+  },
+  parentTips: {
+    selfCare: [
+      'If the regression is finally easing, resist the urge to stay up late "catching up" on things. Use any improved nighttime sleep to actually sleep — your body has a real debt to repay.',
+      'Four and a half months in, many parents feel the emotional complexity of this stage: deep love alongside genuine exhaustion, joy alongside the monotony of repetition. All of those feelings are valid and they can coexist.',
+      'If you have a 4-month check-up coming up, write your questions down beforehand — sleep, feeding, development — so you don\'t forget anything in the moment.',
+    ],
+    watchFor: [
+      'Rolling tummy-to-back reliably, and early attempts at back-to-tummy rolling',
+      'Holding a rattle placed in their hand and shaking it with intention',
+      'Vowel-consonant sounds starting to emerge — something like "ah-goo" or proto-syllables',
+      'Visual tracking smooth and consistent across the full visual arc',
+    ],
+    callDoctor: [
+      'Still not rolling from tummy to back by week 18',
+      'No reciprocal cooing or vocal back-and-forth with caregivers',
+      'Not making eye contact or responding to familiar faces',
+      'Seems consistently uncomfortable, arches back during feeds, or is not gaining weight well',
+    ],
+  },
+  dailyFacts: [
+    'The coos your baby is making right now are evolving into something more structured. They\'re experimenting with consonant-vowel combinations — the building blocks of actual words that are still months away.',
+    'Rolling back-to-tummy is harder than tummy-to-back because your baby has to get their arm out of the way mid-roll. When they\'re stuck on their side straining, they are actively problem-solving.',
+    'Your baby can now recognise your face from across the room. The immediate smile when you walk in is not random — it\'s them picking you out of the visual landscape and feeling genuinely happy about it.',
+    'Sleep pressure is real: if your baby is overtired going into a nap, they will often sleep worse, not longer. Shorter wake windows (about 1.5–2 hours at this age) can help them settle faster and sleep more soundly.',
+    'Babies who are held and carried frequently tend to be calmer overall — physical closeness regulates their nervous system in a way that nothing else does at this age.',
+    'Your baby is watching you eat, drink, and talk this week and cataloguing it all. The intense staring is not about the food itself — it\'s about watching you, which is their absolute favourite activity.',
+    'The visual system and the motor system are increasingly communicating: your baby sees something, reaches for it, misses, adjusts, and tries again. This trial-and-error is genuine learning.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-19.js
+++ b/src/data/weeks/week-19.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week19 = {
   week: 19,
-  ageRange: '4.5 months old',
-  title: 'Week 19 — 4.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '4–5 months old',
+  title: 'Week 19 — 4–5 months old',
+  highlight:
+    'Your baby is approaching 5 months and they know it — sitting with hands propped, mouthing absolutely everything, and experimenting with their voice like they\'re discovering an instrument they didn\'t know they had.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.4–7.6 kg / 14–17 lbs, ~64–67 cm / 25–26.5 in',
+    motorSkills:
+      'Many babies are rolling in both directions now, or close to it. The tripod sit — sitting upright with both hands planted on the floor in front for balance — is appearing for some. It\'s a brief, wobbly affair, but the fact that they can hold the position at all is significant. Reaching is increasingly accurate. Everything that gets grabbed goes straight to the mouth for thorough investigation. Growth rate is beginning to slow slightly from the rapid newborn pace.',
+    reflexes:
+      'The parachute reflex — extending arms forward to "catch" when tipped — is developing and will be fully established by around 6–9 months. This protective reflex is essential groundwork for learning to sit and stand safely.',
+  },
+  cognitive: {
+    vision:
+      'Fascinated by mirrors — your baby stares at their own reflection with genuine curiosity and may smile or reach toward it. They don\'t yet understand it\'s themselves, but the face in the mirror is highly engaging. Small objects and fine details capture their attention for longer stretches.',
+    hearing:
+      'Pitch and volume experimentation is a major theme this week. Your baby is exploring the full range of sounds they can make — from quiet murmurs to sharp squeals — almost like they\'re testing the limits of their instrument. They love when you imitate these sounds back.',
+    awareness:
+      'Cause-and-effect understanding is solidifying. Your baby repeats actions that produced interesting results — banging a toy that made a noise, kicking a mobile that moved. This intentional repetition is one of the earliest forms of goal-directed behaviour. They are a scientist running experiments.',
+  },
+  sleep: {
+    totalHours: '12–15 hours/day',
+    nightSleep: 'Improving for most as the regression fades — many seeing a 5–7 hour first stretch',
+    naps: '3–4 naps, though some babies begin consolidating toward 3 more predictable naps',
+    notes:
+      'Most families are through the worst of the 4-month regression by now. If sleep is still very disrupted at week 19, it\'s worth talking to your doctor to rule out other causes (reflux, ear infections, etc). For babies who are sleeping better, this is a good window to start a consistent nap and bedtime routine if you haven\'t already — consistency now pays dividends later.',
+  },
+  feeding: {
+    amount: '120–180 ml (4–6 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–6 feeds per day',
+    hungerCues:
+      'Rooting, mouthing hands, increased alertness and fussiness. Distraction during feeds can be intense now — try a quiet room with minimal visual stimulation for the best results.',
+    notes:
+      'Some babies around this age show intense interest in watching others eat, reaching toward food, or mouthing at the sight of a spoon. These are intriguing signs, but most paediatric organisations recommend waiting until 6 months for solid foods. If your baby seems very hungry after full milk feeds, discuss with your doctor — but more milk is usually the answer, not early solids.',
+  },
+  play: {
+    activities: [
+      'Mirror play: hold your baby in front of a baby-safe mirror and let them study the face looking back — try making expressions together',
+      'Tripod sit practice: support their hips on the floor and let them plant their hands in front — just a few seconds at a time builds huge strength',
+      'Texture exploration: offer a soft cloth, a smooth wooden ring, a crinkly book — their mouth will give each one a full quality-control inspection',
+      'Pitch imitation game: when your baby makes a squealing sound, copy it back. They\'ll almost certainly do it again. This is vocabulary in its earliest form.',
+    ],
+    bonding:
+      'Around this age, many parents start noticing that their baby has distinct preferences — for certain songs, certain toys, certain games — and a clear sense of humour. Lean into that. Discovering what makes your particular baby tick is one of the quiet joys of this stage. You are becoming an expert in a subject no one else in the world knows as well as you do: this specific small person.',
+  },
+  parentTips: {
+    selfCare: [
+      'If sleep is improving, your energy may be returning — but take it slow. Jumping back into everything at once often leads to crashing. Prioritise one or two things that genuinely matter to you.',
+      'Five months is approaching, which is a good time to think ahead about the 6-month solid food introduction. Reading a bit now (purées vs baby-led weaning, allergen introduction) means less overwhelm when the time comes.',
+      'Check in with yourself about how you\'re feeling emotionally, not just physically. Postnatal mood disorders can emerge or worsen in the 3–6 month window, not just in the first weeks.',
+    ],
+    watchFor: [
+      'Rolling in both directions, or nearly there',
+      'Tripod sitting — upright with hands on the floor for brief moments',
+      'Mouthing objects deliberately as a form of exploration',
+      'Experimenting with pitch and volume in vocalisations',
+    ],
+    callDoctor: [
+      'Not reaching for or grasping objects by now',
+      'Does not seem interested in faces or social interaction',
+      'Not bearing any weight on legs when held upright (just as a developmental check)',
+      'Consistently seeming uncomfortable, not settling, or not gaining weight',
+    ],
+  },
+  dailyFacts: [
+    'When your baby stares at themselves in the mirror, they are genuinely puzzled by what they see — but that puzzlement is rich sensory and social processing. Self-recognition won\'t come for another year or so, but this is the beginning.',
+    'The tripod sit (sitting with hands on the floor for support) is a major precursor to independent sitting. Even 10 seconds at a time strengthens the core muscles your baby needs to get there.',
+    'Your baby\'s growth rate is starting to slow down this month. They\'ll still grow quickly, but not at the dramatic newborn pace — which means fewer sudden size jumps but steady, visible development.',
+    'Mouthing objects is a completely normal and important developmental behaviour. The mouth has the densest concentration of sensory nerves of any part of the body at this age — it\'s literally how they learn what things are.',
+    'The squeals and high-pitched sounds your baby is experimenting with are intentional vocal exploration, not random noise. They are testing what their vocal cords can do.',
+    'Every time your baby repeats an action to get the same interesting result — like kicking a toy to hear it rattle — they are demonstrating cause-and-effect reasoning. That\'s a significant cognitive milestone.',
+    'Babies this age often sleep better after a calm, consistent bedtime routine — bath, feed, song, sleep. Even a short 10-minute routine signals the brain that sleep is coming and helps the transition.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-20.js
+++ b/src/data/weeks/week-20.js
@@ -1,14 +1,79 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week20 = {
   week: 20,
-  ageRange: '4.5 months old',
-  title: 'Week 20 — 4.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '5 months old',
+  title: 'Week 20 — 5 months old',
+  highlight:
+    'Five months old — your baby is sitting with noticeably less help, rolling both ways, and blowing raspberries at you with the confidence of someone who has truly mastered a skill. They have.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.5–7.8 kg / 14.5–17 lbs, ~64–68 cm / 25–27 in',
+    motorSkills:
+      'Sitting with less support is the headline this week — many babies can sit with hands propped in front for 30 seconds or more. Rolling both ways is established or nearly so. Toy transfer is emerging: your baby picks up an object in one hand and deliberately moves it to the other. Blowing raspberries (that wonderful lip-buzzing noise) is in full effect — it\'s actually excellent oral motor development. Legs are strong; when held upright they bear significant weight and bounce enthusiastically.',
+    reflexes:
+      'The parachute reflex continues to develop. Fine motor control is improving — your baby is starting to rake small objects toward themselves with their fingers, a precursor to the pincer grip that comes around 9 months.',
+  },
+  cognitive: {
+    vision:
+      'Fascination with small details is at a peak — specks on the floor, the pattern on your shirt, the movement of a curtain. Depth perception is good enough that your baby will hesitate at a visual cliff (a sudden drop in surface) — this protective instinct is newly online.',
+    hearing:
+      'Responds to their name consistently and reliably. Listens to conversations between adults with obvious interest, looking back and forth between speakers. Begins to associate certain sounds with events — the sound of a zip might mean going outside.',
+    awareness:
+      'Some babies begin showing very early signs of interest in solid foods this week: watching intently as you eat, opening their mouth when they see a spoon, leaning toward food. This is fascinating and worth noting, but solid readiness requires several signs together — not just food interest. Sleep may be becoming more predictable as daytime patterns consolidate.',
+  },
+  sleep: {
+    totalHours: '12–15 hours/day',
+    nightSleep: 'Many babies back to 6–8 hour first stretches, sometimes longer',
+    naps: '3 naps for most, with wake windows around 1.5–2.5 hours between each',
+    notes:
+      'Sleep is often more predictable at 5 months than it has been for the past month. Many families are finding that a consistent nap schedule is emerging naturally — a longer morning nap, a mid-afternoon nap, and a shorter late-afternoon catnap. If nights are still very disrupted, gentle sleep coaching techniques are appropriate from this age and have good evidence behind them.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–6 feeds per day',
+    hungerCues:
+      'Rooting, mouthing, reaching toward breast or bottle, fussiness. Your baby\'s hunger cues are becoming easier to read as their communication becomes more intentional.',
+    notes:
+      'Breast milk or formula remains the complete nutrition source. If your baby is watching you eat with intense interest, that\'s developmentally appropriate curiosity — not a sign they need solids yet. The recommendation is 6 months, and starting too early increases the risk of digestive issues and allergies. One more month to go.',
+  },
+  play: {
+    activities: [
+      'Toy transfer encouragement: hand your baby a toy in their right hand, then offer another to their left and watch them figure out the transfer problem',
+      'Raspberry symphony: blow raspberries at your baby and see if they blow them back — oral motor development disguised as the silliest game possible',
+      'Supported standing: hold your baby upright on your lap or a firm surface and let them bounce — they absolutely love it and it builds leg strength',
+      'Cause-and-effect toys: a button that makes a sound, a toy that lights up when squeezed — your baby is primed to discover how these work right now',
+      'Peek-a-boo with a cloth: hold a muslin over your face, pause, then drop it with a smile — the anticipation and reveal is perfect for this stage of object permanence development',
+    ],
+    bonding:
+      'Five months is often when parents describe really starting to enjoy this. The fog lifts a little. Your baby is genuinely fun — they laugh, they have opinions, they do things that make you want to call someone and describe it. Write these things down, or voice-memo them. You will not remember the exact details, and you will want to.',
+  },
+  parentTips: {
+    selfCare: [
+      'If you\'re back at work or approaching a return, the emotional complexity of that transition is real — grief, relief, guilt, and pride can all show up simultaneously. All of it is normal.',
+      'Five months is a good time to revisit your own health checks if you\'ve been putting them off — GP visits, dental, anything that got shelved in the new-baby chaos.',
+      'Your baby is now robust enough to enjoy more varied environments. Getting outside — a park, a café, a walk — is good for both of you in ways that go beyond fresh air.',
+    ],
+    watchFor: [
+      'Sitting with hands propped for 30 seconds or more',
+      'Rolling reliably in both directions',
+      'Transferring a toy from one hand to the other',
+      'Responding to their own name consistently',
+    ],
+    callDoctor: [
+      'Not rolling in either direction by 5 months',
+      'Not bearing weight on legs when held upright',
+      'No babbling or vocal experimentation',
+      'Does not show interest in reaching for objects',
+    ],
+  },
+  dailyFacts: [
+    'Blowing raspberries isn\'t just amusing — it\'s your baby strengthening the oral muscles they\'ll need for speech. The lips, tongue, and jaw are all getting a workout.',
+    'Toy transfer (moving an object from one hand to the other) sounds simple but requires your baby\'s two brain hemispheres to coordinate. It\'s a genuine cognitive milestone, not just a cute trick.',
+    'At 5 months, many babies have roughly tripled their birth weight. The rapid early growth is slowing, but the brain continues to develop at an extraordinary rate well into childhood.',
+    'Your baby\'s depth perception is now developed enough that they will hesitate at a visual drop — a glass floor over a drop, for instance. This "visual cliff" response is a hardwired protective instinct.',
+    'The consistent bedtime routine you build now will pay dividends for years. Even at 5 months, a bath-feed-song sequence starts to cue the brain that sleep is coming.',
+    'Babies who engage in a lot of floor play this month — tummy time, rolling, reaching — are building the core strength and proprioception they need for sitting, crawling, and walking. Time on the floor matters.',
+    'It\'s normal for solid food interest to appear before 6 months — but interest alone isn\'t readiness. The full checklist includes being able to sit with minimal support, having lost the tongue-thrust reflex, and showing good head control.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-21.js
+++ b/src/data/weeks/week-21.js
@@ -3,12 +3,76 @@ export const week21 = {
   week: 21,
   ageRange: '5 months old',
   title: 'Week 21 — 5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  highlight:
+    'Your baby is reaching across their midline, playing with their feet, and starting to babble real consonant sounds — da, ba, ma — not yet as words, but as joyful vocal exploration. Language is loading.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.6–8.0 kg / 14.5–17.5 lbs, ~64–68 cm / 25–27 in',
+    motorSkills:
+      'Sitting with minimal support is improving week by week — many babies can balance for a minute or more with just a light hand at their back or hips. Reaching across the midline (grabbing a toy on the right side with the left hand) is a big new skill that shows cross-hemisphere brain coordination. Feet are a major fascination: your baby grabs their feet, brings them to their mouth, and uses them as toys. A 5-month growth spurt is possible this week — expect increased hunger and fussiness for 2–3 days.',
+    reflexes:
+      'Voluntary motor control is dominant now. The protective parachute reflex continues to strengthen. Fine motor development is progressing — a raking grasp with fingers is well-established, and your baby is starting to explore individual finger movements.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention is sharp and sustained. Your baby can track a fast-moving toy without losing it. Face recognition is excellent — they not only know familiar people but seem to remember people they\'ve seen a few times before. Colour preferences are emerging, with bright primaries and high-contrast patterns remaining favourites.',
+    hearing:
+      'The babbling that starts this week — da, ba, ma, ga — is produced without meaning yet, but the sounds are the exact building blocks of most human languages. Your baby is essentially practising phonemes. Singing to them is as developmentally valuable as talking.',
+    awareness:
+      'Early signs of separation awareness may appear: your baby tracks where you go when you leave the room and may fuss briefly. This is the beginning of stranger awareness and healthy attachment, not a problem to be solved. Object permanence is strengthening — they search more persistently for hidden objects.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: 'Many babies managing 6–9 hour first stretches; overnight feeds typically 1–2',
+    naps: 'Transitioning toward 2 longer naps for some, while others still take 3 shorter naps',
+    notes:
+      'The 2-nap transition often starts showing up around 5–6 months. You\'ll notice your baby starting to resist the third nap, or that it\'s too late in the day without disrupting bedtime. There\'s no rush — follow your baby\'s lead. If the 5-month growth spurt hits, expect a few nights of increased feeding before things settle back.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–6 feeds per day',
+    hungerCues:
+      'Clear and communicative now — reaching, opening mouth, fussing, and sometimes simply staring at you with intense need. Growth spurt hunger is more urgent and harder to satisfy temporarily.',
+    notes:
+      'If you\'re breastfeeding through a growth spurt, your supply will catch up within 2–3 days of increased demand — this is normal supply-and-demand regulation, not a supply problem. Formula-fed babies may need slightly larger volumes for a few days. Solid foods are still not recommended for another few weeks.',
+  },
+  play: {
+    activities: [
+      'Feet play: let your baby grab, mouth, and generally go to town on their own feet — it\'s proprioception, body awareness, and flexibility all in one',
+      'Cross-midline reaches: hold a toy on one side and slowly move it to the other side of their body — this encourages the reaching-across movement that builds brain connectivity',
+      'Babble back: when your baby says "ba-ba" or "da-da", say it back with different inflections. You\'re having a real conversation — it just uses a limited vocabulary.',
+      'Supported standing bouncing: hold them upright and let them bounce vigorously on your lap or a firm surface — the leg strength and joy both peak at this age',
+    ],
+    bonding:
+      'Separation awareness is beginning, which means something important: your baby is forming a clear internal model of you. They know you exist, they know you come back, and they are just starting to manage the feelings that come with your absence. When you leave and return consistently and warmly, you are building the secure attachment that will give them confidence to explore the world. Every return matters.',
+  },
+  parentTips: {
+    selfCare: [
+      'A 5-month growth spurt can arrive suddenly and feel like a regression — a few days of clingy, hungry, poorly sleeping baby after a calmer week. Knowing it\'s temporary (usually 2–3 days) makes it much easier to ride out.',
+      'If you\'ve been meaning to make an appointment for something — dentist, GP, physio for your own body — now is the time. Five months of carrying and feeding takes a physical toll.',
+      'Start thinking about the 6-month solid food introduction if you haven\'t. Deciding between purées and baby-led weaning (or a combination) now means less overwhelm when the time comes.',
+    ],
+    watchFor: [
+      'Reaching across the midline — grabbing things on one side with the opposite hand',
+      'Playing with feet — grabbing, mouthing, examining them with real interest',
+      'Consonant babbling: da, ba, ma, ga sounds in varied combinations',
+      'Sitting with minimal support for at least 30–60 seconds',
+    ],
+    callDoctor: [
+      'Not sitting with any support or showing core strength in upright positions',
+      'No consonant sounds or babbling by 5 months',
+      'Not showing any signs of object permanence — no searching for hidden objects',
+      'Seems to have lost skills they previously had (rolling, reaching, vocalising)',
+    ],
+  },
+  dailyFacts: [
+    'The "da-da" and "ma-ma" sounds your baby makes right now are not intentional — they are practising phonemes that happen to be the sounds most languages use for parents. Meaning comes later, around 10–14 months.',
+    'Reaching across the midline is more significant than it looks. It requires the two hemispheres of the brain to work together via the corpus callosum, and is a foundation for reading and writing years from now.',
+    'Foot-to-mouth play is excellent for body awareness and flexibility. Babies who do a lot of this tend to have better body proprioception — the sense of where their body is in space.',
+    'Growth spurts typically last 2–3 days. During that time, increased hunger, fussiness, and disrupted sleep are all normal. After it passes, your baby may seem noticeably bigger or more capable.',
+    'When your baby fusses briefly as you leave the room, that\'s object permanence and attachment both working correctly. They know you exist, they want you, and they\'re communicating that clearly.',
+    'Five months is often the point where parents start to feel like themselves again — more sleep, a more predictable baby, a growing sense of confidence. If you\'re not there yet, you\'re getting closer.',
+    'The more you talk to your baby during everyday activities — narrating what you\'re doing, naming objects, describing the world — the larger their eventual vocabulary. These are the best formative conversations.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-22.js
+++ b/src/data/weeks/week-22.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week22 = {
   week: 22,
-  ageRange: '5 months old',
-  title: 'Week 22 — 5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '5–6 months old',
+  title: 'Week 22 — 5–6 months old',
+  highlight:
+    'Six months is almost here — and so, possibly, is the first tooth. Your baby may be sitting briefly without support and pivoting on their tummy, all while navigating another developmental leap that might be wrecking your nights.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.7–8.2 kg / 15–18 lbs, ~65–69 cm / 25.5–27 in',
+    motorSkills:
+      'Some babies can sit briefly without any support now — a few seconds to a minute before toppling. Pivoting on the tummy is a new skill: your baby pushes with their arms and rotates in a circle, turning to face a toy that\'s just out of reach. Proto-crawling movements are appearing — pushing up high on straight arms, rocking back and forth, or even moving backward by accident. Teething may begin: the lower central incisors are usually first to appear, though the timing varies enormously.',
+    reflexes:
+      'The raking grasp is well-established. Some babies begin showing the early stages of a pincer grasp — using thumb and forefinger to pick up objects — though this is more common at 8–9 months. Leg pushing during standing is strong and vigorous.',
+  },
+  cognitive: {
+    vision:
+      'Visually sophisticated now — your baby distinguishes similar-looking objects and shows clear aesthetic preferences. They stare at the face of a stranger with careful assessment. Tracks fast-moving objects without difficulty. Looks for objects that fall or are hidden, demonstrating strong object permanence.',
+    hearing:
+      'Babbling is becoming more varied and melodic — more like a real, conversational cadence with rises and falls. Your baby may stop and listen intently when you start speaking, then "answer" when you stop. Reacts to music with swaying, leg pumping, and obvious pleasure.',
+    awareness:
+      'Shows clear preferences for specific toys and pushes away or turns from things they don\'t want. May wake more frequently at night due to the developmental leap of this period — brain growth is intensive and sometimes disrupts sleep even after the regression has passed. Stranger awareness is increasing: welcomes familiar people enthusiastically but eyes strangers with measured caution.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: 'Possibly more disrupted again this week due to developmental leap — extra waking is common',
+    naps: 'Moving toward 2 naps for many, though some still take 3; morning nap typically 1–1.5 hours',
+    notes:
+      'A developmental leap around 5.5–6 months often causes sleep disruption even in babies who had been sleeping reasonably well. This is different from the 4-month regression — it\'s more about cognitive excitement and less about sleep architecture change. It typically passes within 1–2 weeks. If teething has started, a chilled teether before bed can help take the edge off.',
+  },
+  feeding: {
+    amount: '150–210 ml (5–7 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–6 feeds per day',
+    hungerCues:
+      'Clear and intentional — reaching, opening mouth, turning head toward you. Teething can sometimes suppress appetite temporarily; offer more frequent, smaller feeds if your baby seems to find sucking uncomfortable.',
+    notes:
+      'You\'re one week or two away from the 6-month solid food milestone. Now is a great time to decide your approach — purées, baby-led weaning, or a combination — and stock up on bibs, a suction bowl, and a good high chair. The mess is coming and it\'s worth being prepared.',
+  },
+  play: {
+    activities: [
+      'Tummy time pivoting: place a toy just out of reach to the side during tummy time and watch them rotate toward it — actively encourages that pivot skill',
+      'Sitting triangle: sit on the floor with your legs in a V shape and your baby between your legs, with their hands on the floor — this gives them a safe scaffolded environment to practise unsupported sitting',
+      'Teething toys: chilled (not frozen) teething rings, silicone teethers, and clean damp cloths give gums relief and something satisfying to chew',
+      'More complex peek-a-boo: hide behind a cushion, a door frame, your hands — object permanence is strong enough now that the anticipation of your reappearance is part of the fun',
+    ],
+    bonding:
+      'Your baby\'s preferences are crystal clear now — they know exactly what they want and they communicate it with full-body enthusiasm or full-body protest. Meeting those preferences where you can, and holding boundaries warmly when you can\'t, is the dance of secure attachment. You don\'t have to say yes to everything to be a good parent. Showing up consistently is what matters.',
+  },
+  parentTips: {
+    selfCare: [
+      'If sleep has gone sideways again this week, know that it\'s almost certainly the developmental leap and not something you did or didn\'t do. Regressions feel personal; they\'re not.',
+      'Teething can start now and the uncertainty of "is this the tooth?" can be maddening. Signs of actual teething: drool, gum rubbing, biting, fussiness. Fever above 38°C / 100.4°F is not teething — it means something else and warrants a call to your doctor.',
+      'Six months is nearly here. If you\'ve been on parental leave, you may be approaching decisions about return to work and childcare. Give yourself grace — these are hard decisions and there is no objectively right answer.',
+    ],
+    watchFor: [
+      'Brief unsupported sitting — even 5–10 seconds is significant progress',
+      'Pivoting on tummy to reach things placed to the side',
+      'Proto-crawling movements: rocking, pushing backward, getting up on hands and knees',
+      'First signs of teething: drool, gum sensitivity, biting on everything',
+    ],
+    callDoctor: [
+      'Not able to hold head steady and upright in all positions',
+      'Fever above 38°C / 100.4°F — this is not teething and needs assessment',
+      'Not showing any object permanence or searching for hidden objects',
+      'Significant regression in skills previously mastered',
+    ],
+  },
+  dailyFacts: [
+    'The lower central incisors (the two bottom front teeth) are usually the first to appear, typically between 6 and 10 months — but anywhere from 4 months to 12 months is within the normal range.',
+    'Pivoting on the tummy might look random, but it\'s a coordinated movement requiring your baby to push asymmetrically with their arms. It\'s an important stepping stone toward crawling.',
+    'Proto-crawling movements often look like a baby going backward, getting frustrated, and ending up further from the toy they wanted. The backward push is a normal phase — forward motion comes soon after.',
+    'Sleep disruption during a developmental leap is a sign your baby\'s brain is working overtime to integrate new skills. Frustrating, but genuinely a good sign.',
+    'Teething pain is most intense in the 3–5 days before a tooth erupts and the 1–2 days after it breaks through the gum. Once it\'s through, most babies settle quickly.',
+    'Your baby\'s babbling is developing a conversational structure — turns, pauses, rises and falls. When you have "conversations" with them by taking turns, you\'re teaching pragmatics, which is how language actually works in real life.',
+    'A chilled teething ring (cooled in the fridge, not the freezer) can provide significant gum relief. The cold reduces inflammation and the firm texture gives something satisfying to bite.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-23.js
+++ b/src/data/weeks/week-23.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week23 = {
   week: 23,
-  ageRange: '5.5 months old',
-  title: 'Week 23 — 5.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '6 months old',
+  title: 'Week 23 — 6 months old',
+  highlight:
+    'One week away from the half-year mark, your baby may be sitting unsupported for real stretches, showing you a first tooth, and starting to treat strangers with a healthy amount of suspicion. They\'re becoming a fully-fledged person.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.8–8.4 kg / 15–18.5 lbs, ~65–69 cm / 25.5–27 in',
+    motorSkills:
+      'Many babies can sit unsupported for several seconds to a minute or more — they topple, you right them, they sit again. The 6-month growth spurt is starting for some, bringing increased hunger and a few days of disrupted sleep. The first tooth may be visible, just breaking through the gum surface. All senses are working together in a coordinated way that wasn\'t possible a couple of months ago: your baby hears something, looks for it, reaches for it, grabs it, and puts it in their mouth — one smooth, multi-sense sequence.',
+    reflexes:
+      'Sitting balance reflexes are developing — when your baby starts to tip to one side, they sometimes extend an arm to catch themselves. This protective sideways reaching will become more reliable over the coming weeks.',
+  },
+  cognitive: {
+    vision:
+      'All visual processing systems are working together fluidly. Your baby uses both eyes as a team for detailed depth perception. They scan the whole room when entering a new environment, assessing it systematically rather than just following movement.',
+    hearing:
+      'Stranger awareness shows up in auditory processing too — your baby listens differently to an unfamiliar voice versus yours. They may quieten and assess before responding to someone new, whereas your voice still produces an immediate response.',
+    awareness:
+      'Object permanence is strong: your baby searches persistently for objects that disappear. Stranger awareness is increasing noticeably — new people may be met with a long stare, lip trembling, or a turn toward you for reassurance. The 6-month growth spurt may begin this week, bringing increased hunger, clinginess, and disrupted sleep for 2–4 days.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: 'Typically 6–9 hours for first stretch, then 1–2 additional shorter sleeps',
+    naps: '2–3 naps; many babies beginning to consolidate toward a firm 2-nap schedule',
+    notes:
+      'The 6-month growth spurt, teething, and developmental leap can all converge around now, making sleep feel suddenly worse after a period of improvement. If multiple things are hitting simultaneously, the disruption usually passes within 1–2 weeks as each factor resolves. Consistent routines are your best tool through this period.',
+  },
+  feeding: {
+    amount: '150–210 ml (5–7 oz) per feed if bottle-feeding',
+    frequency: 'Every 3–4 hours, roughly 5–6 feeds per day',
+    hungerCues:
+      'Urgent and clear — reaching, opening mouth widely, fussing immediately. Growth spurt hunger can feel insatiable for a few days and is genuinely not satisfiable in a single larger feed; more frequent feeds work better.',
+    notes:
+      'One week until the official 6-month mark and the green light for solid foods. If your baby is watching every bite you eat with obvious longing, it\'s almost time. Use this week to have everything ready: a high chair or feeding seat, first spoons, bibs, and a flexible mindset about mess.',
+  },
+  play: {
+    activities: [
+      'Sitting practice with toys: sit your baby on a firm surface surrounded by cushions, place toys in front of them, and let them reach — the slight instability makes their core work to compensate',
+      'Cause-and-effect toys: stacking cups, toys with buttons that produce sounds, simple shape sorters — your baby is primed to discover how things work',
+      'Outdoor exploration: if weather allows, sit on a blanket outside and let your baby experience grass, leaves, and the sensory richness of the natural world for the first time',
+      'Social referencing practice: put your baby in new situations (a new room, a new person) and let them see your calm, smiling face — they will take their cue from you',
+    ],
+    bonding:
+      'Stranger awareness is not a problem — it\'s a profound sign of secure attachment. Your baby is anxious around strangers precisely because the bond with you is so clear and so strong that anyone else feels different by comparison. When they turn to check your face in a new situation, they are using you as their emotional barometer. Stay calm, stay warm, and they will gradually open up. This is healthy human development working exactly as intended.',
+  },
+  parentTips: {
+    selfCare: [
+      'The 6-month check-up is likely happening in the next week or two — it\'s usually one of the more reassuring ones. Bring your questions about solids, sleep, and development. Your doctor has answered all of them before.',
+      'If your baby is suddenly clingy and stranger-wary after being an easygoing social butterfly, try not to take it personally on their behalf. It\'s not a problem with how you\'ve raised them; it\'s healthy attachment doing its job.',
+      'Think about your own support network as you head into the second half of the first year. Who are the people you can call on? Parenting continues to get more physically active and socially complex.',
+    ],
+    watchFor: [
+      'Unsupported sitting for several seconds to over a minute',
+      'First tooth visible at the gumline (lower central incisors first)',
+      'Strong object permanence — searching for toys that disappear',
+      'Stranger awareness increasing — caution with unfamiliar people',
+    ],
+    callDoctor: [
+      'Not sitting with any support or showing trunk control in upright positions',
+      'Fever above 38°C / 100.4°F — not a teething symptom',
+      'Not babbling consonant sounds (da, ba, ma) by now',
+      'Loss of any previously acquired skill — rolling, reaching, or vocalising',
+    ],
+  },
+  dailyFacts: [
+    'Stranger awareness is one of the clearest signs that your baby has a secure attachment to their primary caregivers. It literally could not happen without that strong bond existing first.',
+    'The 6-month growth spurt is often felt more in the feeding than in visible physical change — a few days of seemingly bottomless hunger, then a return to normal. The weight and length gain happens in the background.',
+    'All five senses are now working together in coordinated sequences. Your baby\'s brain is integrating sensory information across modalities in a way that wasn\'t possible even a few weeks ago.',
+    'Object permanence at this stage means your baby actively searches for things that disappear — they have a mental model of objects that persist when out of sight. This is one of the most significant cognitive achievements of the first year.',
+    'A first tooth breaking through is exciting, but the gum inflammation before it appears is often the painful part. Once the tooth is through the surface, most babies settle within a day or two.',
+    'Social referencing — looking at your face when unsure about something new — is a survival strategy. Your calm response to a new situation tells your baby\'s nervous system "this is safe." Your facial expression is their first piece of information.',
+    'With one week until 6 months, this is a good time to do one last read about solid food introduction if you haven\'t — whether you\'re starting with purées, finger foods, or both. The mess is worth it.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-24.js
+++ b/src/data/weeks/week-24.js
@@ -1,14 +1,79 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week24 = {
   week: 24,
-  ageRange: '5.5 months old',
-  title: 'Week 24 — 5.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '6 months old',
+  title: 'Week 24 — 6 months old',
+  highlight:
+    'Half a year. Your baby has gone from a creature of pure reflex to a social, curious, reaching, laughing person — and you have kept a human alive and thriving for six months. Both of those things are remarkable.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~6.9–8.5 kg / 15–19 lbs, ~65–70 cm / 25.5–27.5 in — roughly triple their birth weight',
+    motorSkills:
+      'Many babies sit unsupported for stretches of a minute or more. Hands are in constant use: transferring objects, banging things together, bringing everything to the mouth. Some babies are starting to get up on all fours and rock — the precursor to crawling. A first tooth is often visible right around 6 months, though the range of 4–12 months is all normal. A two-nap schedule is consolidating for most.',
+    reflexes:
+      'Protective sideways extension when tipping (equilibrium reaction) is strengthening and becoming more reliable. The grasping reflex has fully evolved into voluntary, deliberate grip — open, close, squeeze, release, all intentional.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention is strong and sustained. Your baby examines objects from all angles before mouthing them — turning, rotating, inspecting with real method. Tracks fast objects easily. Recognises the high chair as a signal that feeding is coming.',
+    hearing:
+      'Responds to their name instantly and consistently — this is a reliable 6-month milestone. Babbling is rich, melodic, and increasingly conversational in rhythm. Reacts to emotional content in voices: laughter is met with laughter, a sharp "no" stops them mid-action.',
+    awareness:
+      'Object permanence is robust. Your baby understands that the world continues to exist when they can\'t see it. Hands are now primary exploration tools — they pick up, examine, pass between hands, bang on surfaces, and investigate with genuine scientific purpose. The 6-month check-up is the milestone visit.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: 'Many babies achieving 6–9 hour first stretch; some doing longer',
+    naps: '2 naps for many — a morning nap around 9–10 am and an afternoon nap around 1–3 pm',
+    notes:
+      'The 2-nap schedule consolidates for many babies around 6 months. A clear routine (morning nap roughly 2–2.5 hours after waking, afternoon nap roughly 2–3 hours after morning nap ends) works well for most. If you\'re starting solids, introducing them after a milk feed and before nap time can help with digestion and settling.',
+  },
+  feeding: {
+    amount: '150–210 ml (5–7 oz) per feed if bottle-feeding; solid foods beginning in tiny amounts',
+    frequency: 'Milk: 5–6 feeds per day. Solids: once a day to start, a few teaspoons only',
+    hungerCues:
+      'Clear and communicative. When solids are offered, your baby will lean forward, open their mouth, and reach for the spoon if interested — or turn away, close their mouth, or push the spoon away if not. Both are valid responses. Respect the refusal.',
+    notes:
+      'Starting solids is exciting and messy and often anticlimactic. Most of the first few sessions will end up on the bib, the high chair, and you. That\'s fine — the goal at this stage is exploration and experience, not nutrition. Milk is still the primary nutrition source for the next several months. Introduce one new food at a time and wait 3 days before introducing another, so you can identify any reactions. Start with vegetables, soft cooked finger foods, or iron-rich purées.',
+  },
+  play: {
+    activities: [
+      'First tastes: offer a small amount of mashed sweet potato, avocado, or puréed vegetable on the tip of a spoon — let your baby decide what to do with it, no pressure',
+      'Banging play: offer two toys and see if your baby bangs them together — they may try to reproduce the sound deliberately once they\'ve done it accidentally',
+      'All-fours rocking: if your baby gets into quadruped position, gently rock them forward and back — you\'re building the motor pattern for crawling',
+      'Name-response game: say their name from different positions in the room and celebrate when they find you — it reinforces the name recognition that\'s solidifying this week',
+      'Stacking and nesting: simple stacking cups introduced now will be a staple for the next two years — at 6 months, mostly knocking them over, which is also excellent',
+    ],
+    bonding:
+      'Six months is a moment worth marking. Look at photos from week one and look at your baby now. The transformation is staggering — and you were there for every single day of it. The bond you\'ve built is not just emotional; it\'s wired into your baby\'s nervous system, their sense of safety, their ability to explore. Everything good that comes next is built on the foundation you\'ve been laying since before they were born. You\'re doing it.',
+  },
+  parentTips: {
+    selfCare: [
+      'The 6-month check-up is one of the more thorough ones — hearing and vision screens, developmental assessment, vaccines, and a full conversation about feeding, sleep, and the months ahead. Go in with questions.',
+      'Half a year of sleep deprivation, physical demands, and emotional intensity is a lot. Check in with yourself honestly. Not "am I coping?" but "am I actually okay?" — they\'re different questions.',
+      'Starting solids is a marathon, not a sprint. The next few months of food introduction are supposed to be slow, playful, and low-pressure. Try not to attach too much outcome to any individual meal.',
+    ],
+    watchFor: [
+      'Sitting unsupported for a minute or more — this is the 6-month sitting milestone',
+      'Responding to their name consistently and immediately',
+      'Beginning to explore solid foods with interest (or appropriate refusal)',
+      'Getting up on hands and knees or rocking in that position',
+    ],
+    callDoctor: [
+      'Not sitting with support or showing poor trunk control',
+      'Not responding to name or to familiar voices',
+      'Not babbling (da, ba, ma sounds) by 6 months',
+      'Does not bear weight on legs when held upright, or seems very stiff or floppy',
+    ],
+  },
+  dailyFacts: [
+    'At 6 months, your baby has roughly tripled their birth weight. The brain has doubled in size from birth. These numbers are extraordinary when you stop to consider them.',
+    'The 6-month check-up usually includes a hearing screen if not done previously. Hearing is foundational to language development, so this check really matters.',
+    'First foods are about learning, not nutrition. It takes most babies weeks to months before they\'re eating meaningful quantities. Milk carries the nutritional load throughout — solid foods are supplementary until around 12 months.',
+    'When your baby responds to their name, their brain is making a specific leap: recognising a sequence of sounds as self-referential. It\'s a precursor to self-awareness.',
+    'Banging objects together is deliberate exploration of cause and effect. When your baby makes a sound by accident, then tries to make it again — that\'s scientific method in its most fundamental form.',
+    'The two-nap schedule that consolidates around now is often the most sustainable schedule for babies through to around 14–18 months, when the transition to one nap usually begins.',
+    'Starting solids with vegetables before fruit (though not strictly necessary) may help your baby develop a taste for less sweet foods. Either way, variety and repeated exposure — not pressure — is what builds adventurous eaters.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-25.js
+++ b/src/data/weeks/week-25.js
@@ -3,12 +3,76 @@ export const week25 = {
   week: 25,
   ageRange: '6 months old',
   title: 'Week 25 — 6 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  highlight:
+    'Solids are underway and the learning curve is steep for everyone — mostly your baby, but honestly also you. Slow is the right pace. Your baby is also rolling freely, babbling richly, and may be army crawling toward something they want.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.0–8.6 kg / 15.5–19 lbs, ~66–70 cm / 26–27.5 in',
+    motorSkills:
+      'Rolling both directions is smooth and frequent — your baby now uses rolling as a deliberate way to get places, not just as a party trick. Some babies are beginning commando crawling (dragging themselves on their belly with forearms), which is a fully valid and often very fast form of locomotion. Others are getting up on hands and knees and rocking. Sitting is stable and confident for most. Using both hands together — banging, clapping, holding a cup with two hands — is well-developed. Some babies can push themselves up to a seated position from their tummy.',
+    reflexes:
+      'Equilibrium reactions (catching themselves when tipping sideways) are becoming more reliable. Fine motor skills are advancing — your baby can pick up smaller objects and is working toward a pincer grasp.',
+  },
+  cognitive: {
+    vision:
+      'Visual discrimination is sophisticated — your baby distinguishes very similar faces, colours, and shapes. They scan their environment systematically and notice things that have been moved or changed. Memory for objects and people is strengthening.',
+    hearing:
+      'Babbling is richer and more varied — longer strings of syllables, more consonant variety, rising and falling intonation that sounds genuinely conversational. Your baby seems to understand that certain sounds mean certain things (the high chair click means food is coming).',
+    awareness:
+      'Object permanence is fully operational — your baby searches actively and persistently for hidden objects. Both hands working together for exploration is a sign of increasing bilateral coordination. Strong object permanence means separation anxiety may be intensifying: your baby knows you exist when you\'re not there and wants you back.',
+  },
+  sleep: {
+    totalHours: '11–14 hours/day',
+    nightSleep: 'Most babies managing 6–9 hours for first stretch; overnight feed often 1, sometimes none',
+    naps: 'Firm 2-nap schedule for most — morning and afternoon, 1–2 hours each',
+    notes:
+      'The introduction of solid foods sometimes briefly disrupts sleep as the digestive system adjusts to processing new foods. This usually settles within a week or two. Keep the milk feeds going — they remain the nutritional foundation. If your baby is waking at night seemingly hungry, offer a milk feed first (solids shouldn\'t replace milk at this stage).',
+  },
+  feeding: {
+    amount: 'Milk: 150–210 ml (5–7 oz) per feed; solids: 1–2 tablespoons per sitting, once or twice a day',
+    frequency: 'Milk feeds: 5–6 per day. Solids: 1–2 times per day, offered after milk',
+    hungerCues:
+      'Well-established for milk. For solids: leaning forward, mouth opening, reaching for the spoon are hunger/interest cues. Turning away, closing mouth, pushing spoon away are fullness/refusal cues — always respected.',
+    notes:
+      'Introducing allergens early is now recommended by most paediatric allergy guidelines. Common allergens — peanut (as smooth peanut butter thinned with breast milk or formula), egg, wheat, fish — should be introduced one at a time with a 2–3 day gap. Your doctor or health visitor can guide you on the right order. Early introduction, not avoidance, reduces allergy risk.',
+  },
+  play: {
+    activities: [
+      'Supported forward crawling: place a toy just out of reach while your baby is on their tummy — let them figure out how to get to it, whether that\'s commando crawling, rolling, or rocking',
+      'Two-handed play: offer a toy that requires both hands — a ball, a stacking cup, a container with a lid — and watch your baby work it out',
+      'Solids exploration: let your baby touch the food before it goes on the spoon. Self-directed sensory experience with food builds acceptance over time, even if nothing gets eaten.',
+      'Babble dialogues: have full "conversations" with your baby using their sounds. Imitate their babble, pause, let them respond. The conversational rhythm is as important as the content.',
+    ],
+    bonding:
+      'Separation anxiety is reaching a peak this week for many babies. If your baby cries when you leave the room, that\'s not a behaviour problem — it\'s secure attachment doing its job. Consistent, warm returns matter more than minimising separations. Play peek-a-boo, leave and come back reliably, and narrate what you\'re doing ("I\'m going to the kitchen, I\'ll be right back"). The predictability is what makes it safe.',
+  },
+  parentTips: {
+    selfCare: [
+      'Introducing solids is a long-game endeavour. Expect mess, refusals, faces of absolute disgust at foods you consider mild, and very slow progress. This is normal. Keep offering, keep it positive, and don\'t count what goes in.',
+      'If separation anxiety is spiking and you\'re feeling guilty about leaving, remember: the distress when you go and the relief when you return are both normal expressions of healthy attachment. Your baby is not damaged by brief separations.',
+      'Check allergen introduction guidelines with your health provider so you have a plan. Going in with a schedule makes it feel less daunting than "introducing everything one by one."',
+    ],
+    watchFor: [
+      'Rolling used purposefully as a means of getting places',
+      'Commando crawling or rocking on hands and knees',
+      'Accepting solid foods — even just tolerating them in the mouth briefly counts as progress',
+      'Using both hands together for two-handed exploration',
+    ],
+    callDoctor: [
+      'Not sitting with minimal support at this point',
+      'Not babbling with consonant sounds',
+      'No interest in reaching for or manipulating objects',
+      'Significant difficulty swallowing or gagging persistently on all foods (not just occasional — all babies gag during solid introduction)',
+    ],
+  },
+  dailyFacts: [
+    'The gagging reflex in babies is positioned further forward in the mouth than in adults — this is a safety feature. Gagging during first foods is normal and protective. Choking is different (silent, distressed, no airway movement) and needs immediate action.',
+    'Commando crawling — dragging on the belly using forearms — is a perfectly valid form of crawling and does not predict anything about future motor development. Some babies skip it entirely; others use it for months.',
+    'When your baby pushes up to sitting from lying on their tummy, they are integrating a complex sequence of muscle activations. It looks effortful because it is — but repetition will make it smooth.',
+    'Early allergen introduction reduces the risk of developing food allergies. The evidence for peanut introduction in particular is very strong: early introduction (before 12 months) significantly lowers peanut allergy risk.',
+    'Separation anxiety is at its most intense between 6 and 18 months, then gradually fades as your baby develops trust that you return consistently. There is no way to avoid it — only to be reliably present through it.',
+    'At this age, food refusal is normal and should be respected. Forcing or pressuring a baby to eat builds a negative association with food that can last years. Repeated calm exposure — without expectation — is what works.',
+    'Your baby\'s babbling this week may sound so conversational that strangers assume they\'re saying words. They\'re not yet — but the cadence, intonation, and rhythm of real speech is all there. The words will come.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-26.js
+++ b/src/data/weeks/week-26.js
@@ -1,14 +1,79 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week26 = {
   week: 26,
-  ageRange: '6 months old',
-  title: 'Week 26 — 6 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '6–7 months old',
+  title: 'Week 26 — 6–7 months old',
+  highlight:
+    'Six months and one week: your baby knows their own name, sits confidently, and is beginning to understand that peekaboo is the funniest game ever invented. The first teeth may be through, and the second half of year one begins in earnest.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.1–8.7 kg / 15.5–19 lbs, ~66–71 cm / 26–28 in',
+    motorSkills:
+      'Sitting is confident and stable for most babies — they can reach to the side or forward without toppling immediately and catch themselves more reliably when they do tip. Everything goes in the mouth with expert efficiency: your baby uses a raking grasp to drag small objects toward them, then closes their fist and brings them in. Some babies are mobile now via commando crawling or rolling; some are pulling to standing when given a hand. First teeth may be fully through — often the two lower central incisors by this point, with the uppers following weeks to months later.',
+    reflexes:
+      'Equilibrium reactions (balance protection) are solidly established in sitting. Your baby instinctively extends an arm when tipping to the side. Pincer grasp is beginning to emerge — some babies can pick up small objects using thumb and forefinger, though it\'s still developing.',
+  },
+  cognitive: {
+    vision:
+      'Visual memory is strong — your baby recognises people, places, and objects they have seen before, even after gaps of several days. Shows visible recognition when entering a familiar environment like the grandparents\' home or a regular café.',
+    hearing:
+      'Responds to their name consistently from across the room, turning immediately and looking for the source. Babbling is complex and long — extended strings of syllables with real intonation patterns. Loves social games with repetitive sound patterns: "round and round the garden," songs with actions, anything rhythmic.',
+    awareness:
+      'Recognises their own name as self-referential — a significant cognitive achievement. Peekaboo reaches its peak appeal around this age because object permanence is strong enough that the disappearance and reappearance is genuinely thrilling. Social games — clapping, waving, taking turns — are increasingly engaging and your baby is learning to take their turn intentionally. Solid foods are becoming a small but real part of daily life.',
+  },
+  sleep: {
+    totalHours: '11–14 hours/day',
+    nightSleep: '6–9 hour first stretch for most; some babies doing longer stretches or close to sleeping through',
+    naps: 'Established 2-nap schedule: morning nap (9–10 am) and afternoon nap (1–3 pm), 1–2 hours each',
+    notes:
+      'The two-nap schedule established around now typically lasts until 14–18 months. If your baby is firmly on two naps and sleeping well at night, you\'ve reached a relatively stable sleep period. If nights are still disrupted, this is an appropriate age for gentle sleep coaching — there is good evidence for its safety and effectiveness from 6 months. Talk to your doctor or a sleep specialist if you\'d like guidance.',
+  },
+  feeding: {
+    amount: 'Milk: 150–210 ml (5–7 oz) per feed; solids: 2–3 tablespoons at 1–2 meals per day',
+    frequency: 'Milk: 4–5 feeds per day. Solids: 1–2 times per day, amounts gradually increasing',
+    hungerCues:
+      'Well-established for both milk and solids. Your baby is getting better at communicating fullness too — turning away, pushing food away, or simply clamping their mouth shut. These signals should always be respected.',
+    notes:
+      'After 2–3 weeks of solid introduction, your baby may have tried 6–10 different foods. Iron-rich foods are a priority at this stage (iron stores from birth begin depleting around 6 months): well-cooked meat, lentils, iron-fortified cereals, leafy greens. Continue milk feeds as the nutritional foundation — solids are complementary, not yet primary.',
+  },
+  play: {
+    activities: [
+      'Peekaboo variations: hide behind your hands, a cloth, a cushion, a door — your baby\'s delight at each reappearance is absolutely genuine and joyful',
+      'Clapping games: clap your hands in front of your baby and encourage them to clap theirs — some babies start bringing their hands together around this age',
+      'Name recognition game: say their name from across the room and see how fast they find you — their response speed has likely improved dramatically',
+      'Finger foods (if developmentally ready): soft cooked carrot sticks, banana slices, well-cooked pasta — foods they can hold and explore, not just purées from a spoon',
+      'Social songs: "If You\'re Happy and You Know It," "Row Your Boat," anything with a clear rhythm and repeated phrases — your baby is learning that music is interactive, not passive',
+    ],
+    bonding:
+      'Your baby knows who you are — not just recognises your face, but understands you in a rich way. They know your smell, your voice, the feel of your hands, the rhythm of how you pick them up. When they reach for you specifically, cry for you specifically, settle for you and not for others, that\'s the result of 26 weeks of showing up. This relationship is the most important one they\'ll ever have, and it\'s already built. Everything from here is deepening what already exists.',
+  },
+  parentTips: {
+    selfCare: [
+      'Six months and a week — take a moment to acknowledge what you\'ve done. Not everything has gone perfectly, and it never does. But you are here, your baby is thriving, and that\'s the only scorecard that matters.',
+      'If you haven\'t established a social connection with other parents of babies the same age, now is a great time. Baby groups, parent cafés, or even a local park can be the start of relationships that matter for years.',
+      'Keep iron-rich foods prioritised in your baby\'s diet — iron deficiency is the most common nutritional gap in the second half of infancy. If you\'re unsure, ask your doctor about whether a check is warranted.',
+    ],
+    watchFor: [
+      'Name recognition — turning immediately and consistently when called',
+      'Sitting confidently with balance recovery when tipping',
+      'Engaging in social games (peekaboo, clapping, turn-taking)',
+      'Solid foods acceptance growing — more going in, less immediately pushed back out',
+    ],
+    callDoctor: [
+      'Not responding to their name by 6 months',
+      'Not babbling or making a variety of sounds',
+      'Not sitting with any support or showing very poor trunk control',
+      'Not showing interest in the world around them, in people, or in objects',
+    ],
+  },
+  dailyFacts: [
+    'Recognising their own name is one of the clearest early signs of self-concept forming. Your baby understands that "their" sound means them specifically — not every baby nearby, not the dog, them.',
+    'Peekaboo is genuinely thrilling to a 6-month-old because object permanence is strong enough that the disappearance is surprising and the return is relieving. It\'s not just a game — it\'s a lesson in "things come back."',
+    'Iron stores from birth begin depleting around 6 months, which is one of the reasons solids introduction is recommended at this age rather than earlier or later. Iron-rich first foods are a priority, not a bonus.',
+    'The two-nap schedule you\'re establishing now is one of the most stable sleep patterns in all of infancy. Most babies will stay on it until 14–18 months, giving you a predictable rhythm for the rest of the first year.',
+    'First teeth timing varies enormously. Some babies are born with a tooth; others don\'t get one until 12–14 months. Neither extreme predicts anything about dental health, intelligence, or development.',
+    'The clapping and waving that your baby may begin to show this week isn\'t just cute — it\'s intentional social communication. They are learning that their body can send messages to other people.',
+    'You have made it through one of the hardest, most transformative years of human experience. The second half of year one gets physically more demanding (mobility is coming) but emotionally richer in ways that make it deeply worthwhile.',
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-27.js
+++ b/src/data/weeks/week-27.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week27 = {
   week: 27,
-  ageRange: '6.5 months old',
-  title: 'Week 27 — 6.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '6–7 months old',
+  title: 'Week 27 — Solid starts and sitting strong',
+  highlight:
+    'Your baby is discovering food — and gravity. Mealtimes are messy, joyful experiments, and dropping things off the highchair tray is their new favourite game (they just invented it on purpose).',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.3–8.5 kg / 16–18.7 lbs, ~65–69 cm / 25.5–27 in',
+    motorSkills:
+      'Sitting is becoming steadier — many babies can hold a tripod-sit (hands on the floor in front) and some are beginning to sit unsupported for a few seconds at a time. On the floor, they are rocking on all fours, rocking forward and back, and figuring out the mechanics of crawling. Picking up objects is increasingly intentional — the pincer grasp (thumb and forefinger working together) is just beginning to emerge, though it is still clumsy.',
+    reflexes:
+      'Primitive reflexes are gone. The parachute reflex — extending arms when tipped forward — is solidifying and will protect your baby as they become more mobile. Movements are largely voluntary and purposeful.',
+  },
+  cognitive: {
+    vision:
+      'Near-adult visual acuity. Depth perception is strong enough that your baby may hesitate at the edge of a raised surface — a sign the visual cliff response is developing. They track fast-moving objects smoothly and are fascinated by small details.',
+    hearing:
+      'Responds to their name reliably. Loves varied tones — silly voices, singing, whispering. Babbling has a conversational rhythm: they "talk," pause, and listen for your response. They are learning the back-and-forth before they have any real words.',
+    awareness:
+      'Object permanence is strengthening — if they drop a toy and it rolls away, they will look for it rather than forgetting it existed. Stranger anxiety is increasing; they may study an unfamiliar face intently before deciding how to feel. Strong social preference for familiar caregivers.',
+  },
+  sleep: {
+    totalHours: '12–15 hours/day',
+    nightSleep: '9–11 hours, though the 6-month sleep regression may be disrupting previously reliable nights',
+    naps: '2–3 naps totalling 2–3.5 hours — many babies are naturally moving toward 2 longer naps',
+    notes:
+      'The 6-month sleep regression is real and it often coincides with the developmental explosion happening right now — sitting, solids, crawling attempts, and increased social awareness all hit at once. If nights have suddenly gotten harder after a good stretch, this is almost certainly why. It is temporary. Stay consistent with whatever routine you have established and resist introducing new sleep props that you will not want to sustain long term.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed if bottle-feeding; 1–2 solid meals of 1–4 tablespoons each',
+    frequency: 'Milk every 3–4 hours (4–5 feeds/day); solids 1–2 times per day alongside milk feeds',
+    hungerCues:
+      'Leaning toward the spoon, opening mouth when food approaches, excited arm movements at mealtime. For milk: same as before — rooting, hand-sucking, increased alertness. Turning away, closing mouth firmly, or pushing the spoon away are clear "I am full" signals — always respect them.',
+    notes:
+      'Solids at this stage are purely exploratory — milk (breast or formula) remains the primary nutrition source until around 12 months. Offer single-ingredient purees or soft finger foods (baby-led weaning style) and expect most of it to go on the floor, face, or ceiling. That is fine. Gagging is normal and different from choking — gagging is loud and the baby is in control; choking is silent and serious.',
+  },
+  play: {
+    activities: [
+      'Drop and fetch: hand them a toy, let them drop it, hand it back. This is object permanence in action and they will not tire of it for months',
+      'Sitting on the floor surrounded by a ring of toys — practice balance by reaching in every direction',
+      'Banging two soft blocks together — bilateral coordination and cause-and-effect all in one',
+      'Mirror play: show them their own reflection and narrate what you see — "That\'s you! Where\'s your nose?"',
+    ],
+    bonding:
+      'Mealtimes are bonding time now too. Sit at the same level, make eye contact, narrate what you are doing, and share in the joy of a new taste landing well (or badly). Eating together as a family — even if your meal looks nothing like their puree — begins building the social rituals around food that will matter for their whole childhood.',
+  },
+  parentTips: {
+    selfCare: [
+      'If the sleep regression has arrived, accept that you are in a temporary hard patch rather than a permanent regression. Lower your expectations for your own productivity and be kind to yourself.',
+      'Mealtime prep for a 6-month-old does not need to be complicated. Ice cube trays of blended vegetables, defrosted as needed, are completely adequate — do not let social media convince you otherwise.',
+      'Your baby is becoming more interesting every single week. Let yourself enjoy that, even when you are tired.',
+    ],
+    watchFor: [
+      'Sitting independently, even for just a few seconds without hands on the floor',
+      'Looking for a dropped or hidden toy — object permanence emerging',
+      'Pincer grasp starting — trying to pick up small things with thumb and forefinger',
+      'Deliberate dropping (not accidental) — this is a cognitive achievement, not naughtiness',
+    ],
+    callDoctor: [
+      'Not sitting with support or showing no interest in bearing weight through their legs',
+      'No babbling or back-and-forth "conversation" attempts',
+      'Showing no interest in solid foods after several weeks of regular offering — worth a chat to rule out sensory or oral motor concerns',
+      'Choking (silent, distressed) during mealtimes — different from the loud gagging that is normal',
+    ],
+  },
+  dailyFacts: [
+    'Babies this age drop things deliberately — not by accident. Dropping is a physics experiment: they are learning about gravity, trajectory, and the fact that objects continue to exist when out of sight. Hand it back every time.', // Day 1
+    'The pincer grasp (using thumb and forefinger together) takes months to refine. Right now your baby is probably using a raking motion with all fingers. By 9–10 months it will be precise enough to pick up a single pea.', // Day 2
+    'Gagging during solids is protective and normal — it means the gag reflex is doing exactly what it should. It looks alarming but your baby is almost always fine. Stay calm, let them work through it, and only intervene if there is silence and genuine distress.', // Day 3
+    'The 6-month sleep regression often coincides with a cognitive leap, teething, and the start of solids — it is a perfect storm. Consistent routine and patience are your best tools. Most families see improvement within 2–6 weeks.', // Day 4
+    'Babies beginning to rock on all fours are typically 2–6 weeks away from crawling. The rocking is strengthening the core and arm muscles they need. Plenty of floor time accelerates this.', // Day 5
+    'Stranger anxiety at this age is developmentally healthy — it means your baby has a clear map of who their safe people are. Do not push reluctant babies toward unfamiliar adults; let them set the pace.', // Day 6
+    'When offering new foods, aim for 10–15 exposures before concluding your baby dislikes something. A screwed-up face on the first try means "this is unfamiliar," not "I hate this forever."', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-28.js
+++ b/src/data/weeks/week-28.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week28 = {
   week: 28,
-  ageRange: '6.5 months old',
-  title: 'Week 28 — 6.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '7 months old',
+  title: 'Week 28 — 7 months, on the move',
+  highlight:
+    'Seven months is when babies get seriously mobile. Army crawling, rocking on all fours, or hauling themselves toward anything interesting — your baby has a destination in mind and they are going to get there.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.5–8.8 kg / 16.5–19.4 lbs, ~66–70 cm / 26–27.5 in',
+    motorSkills:
+      'Many babies are army (commando) crawling now — dragging themselves forward on their elbows and belly with impressive speed and determination. Some are already up on hands and knees crawling properly. Getting into a seated position from crawling is developing: they can push back and sit up from all fours. Banging two objects together is a satisfying new skill. The 7-month growth spurt may add a centimetre or two this week.',
+    reflexes:
+      'All movements are intentional. The parachute reflex is well established — tipped forward, arms shoot out to catch a fall. Protective side-saving (extending an arm sideways to break a fall) is emerging as sitting becomes more confident.',
+  },
+  cognitive: {
+    vision:
+      'Visual memory is strong — they recognise objects they have not seen for several days. Fascinated by small, intricate things (crumbs on the floor, patterns on fabric). Can track objects that disappear and reappear, actively watching where things went.',
+    hearing:
+      'Babbling is now multi-syllabic and varied: "bababa," "dadada," "mamama" are appearing, though without attached meaning yet. They use different sounds for excitement, frustration, and wanting attention. Recognises and responds to their own name consistently across a room.',
+    awareness:
+      'Stranger anxiety is well established — some babies become quite upset around unfamiliar people even in familiar settings. Object permanence is solid: they will search actively for a hidden object. Beginning to understand that other people have intentions and emotional states.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours, increasingly consolidated into one longer block',
+    naps: '2 naps — typically a morning nap around 2–2.5 hours after waking, and an afternoon nap; most babies have dropped the third short catnap by now',
+    notes:
+      'Two naps is the norm from around 6–7 months until somewhere between 15–18 months. If your baby is still on three naps but seems ready to drop one, the first to go is usually the late-afternoon catnap. Watch for a nap becoming a battle, taking more than 20 minutes to fall asleep, or night sleep shortening — all signs the schedule may need adjusting.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; 2–4 tablespoons of solids per meal',
+    frequency: 'Milk 4–5 times daily; solids 1–2 times per day, ideally not right before a milk feed',
+    hungerCues:
+      'At mealtime: leaning in, grabbing for the spoon, excited bouncing. Between meals: same milk hunger cues as before — rooting, hand-sucking, increased alertness. At 7 months, babies are also starting to show clear satiety signals — pushing away, turning head, slowing the pace of eating.',
+    notes:
+      'Texture is the frontier now. If you started with smooth purees, begin introducing lumpier textures — mashed rather than blended, or soft finger foods alongside purees. The transition between textures can take weeks and some babies reject lumps initially. Keep offering alongside familiar foods.',
+  },
+  play: {
+    activities: [
+      'Chase crawling on the floor — crawl away and let them chase you, or put a favourite toy just out of reach to motivate movement',
+      'Container play: a plastic bowl and a few soft blocks they can put in and dump out — simple and endlessly satisfying',
+      'Cause-and-effect toys: anything that makes a sound or lights up when hit, pressed, or shaken',
+      'Floor-time obstacle course: cushions, rolled blankets, and pillows to crawl over and around',
+    ],
+    bonding:
+      'Your baby is watching you constantly and modelling everything. They pick up on your emotional tone — excitement, calm, anxiety, delight. When you get on the floor and play at their level, engage with what they are doing rather than directing them toward something else, and narrate their experience back to them, you are building both their language and their sense of being truly seen. That is attachment in action.',
+  },
+  parentTips: {
+    selfCare: [
+      'Babyproofing becomes urgent now. Get on your hands and knees and look at your home from floor level — what can your baby reach, pull over, or put in their mouth? Act before they can crawl fast, not after.',
+      'The shift to two naps changes your daily rhythm. Build your own rest or work blocks around the nap windows — two longer, predictable naps are actually more manageable than three short unpredictable ones.',
+      'Celebrate the milestone of mobility even though it means more vigilance. A baby who can move independently is developing confidence and autonomy — this is what you wanted.',
+    ],
+    watchFor: [
+      'Army crawling or hands-and-knees crawling — any mode of self-propulsion counts',
+      'Getting from crawling position into sitting independently',
+      'Banging objects together purposefully',
+      'Multi-syllabic babbling (baba, dada, mama) with a conversational back-and-forth rhythm',
+    ],
+    callDoctor: [
+      'No attempts at any form of mobility — not rolling, army crawling, or pivoting — by 7 months',
+      'Babbling that has disappeared after previously being present (loss of skills always warrants a check)',
+      'Extreme stranger anxiety that prevents normal daily functioning or eating',
+      'Not responding to their own name by 7 months',
+    ],
+  },
+  dailyFacts: [
+    'Army crawling (belly on the floor, elbows propelling forward) is a completely valid form of crawling — some babies army crawl for weeks before going to hands-and-knees, and a few skip traditional crawling entirely and go straight to cruising furniture. All are developmentally normal.', // Day 1
+    '"Dadada" and "mamama" appearing in babble is exciting, but at 7 months it is not yet intentional word use. The meaningful attachment of "dada" or "mama" to a specific person typically comes somewhere around 9–12 months.', // Day 2
+    'The 7-month growth spurt can bring increased hunger, clinginess, and disrupted sleep. It usually lasts 2–7 days. Feed more freely, offer extra comfort, and know it will pass.', // Day 3
+    'Babies who army crawl often have surprisingly strong biceps and forearms. The different crawling styles build slightly different muscle groups, but all pathways lead to the same place: walking.', // Day 4
+    'Stranger anxiety peaks somewhere between 8 and 12 months but begins around now. It is a sign of healthy attachment — your baby has a clear mental model of who their safe people are, and everyone else requires careful assessment before they get a smile.', // Day 5
+    'At 7 months, babies begin to use your emotional reactions as information. If they touch something new and you look alarmed, they will become alarmed too. If you stay calm and curious, they often will too — this is called social referencing and it is the beginning of learning from your responses.', // Day 6
+    'Two-nap schedules work best when the first nap happens about 2–2.5 hours after morning wake-up, and the second nap ends by around 4–5 pm to protect night sleep. Small adjustments to these windows make a big difference to how well the day flows.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-29.js
+++ b/src/data/weeks/week-29.js
@@ -2,13 +2,77 @@
 export const week29 = {
   week: 29,
   ageRange: '7 months old',
-  title: 'Week 29 — 7 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 29 — Pulling, pointing, and lumpy food',
+  highlight:
+    'Your baby is becoming a problem-solver. They study their hands, transfer objects between them with growing ease, and are starting to point at the things they want — communication before words.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.6–9.0 kg / 16.8–19.8 lbs, ~66–71 cm / 26–28 in',
+    motorSkills:
+      'Commando crawling is fast and efficient for many; some are now on hands and knees. Pulling to kneel using low furniture is appearing — they grab the edge of the coffee table and haul themselves partway up. Transferring objects hand-to-hand is smooth. The pincer grasp is developing: they are beginning to use the thumb and forefinger rather than a full-hand rake, though precision is still limited. Lateral incisors may begin breaking through, following the central bottom teeth.',
+    reflexes:
+      'Fully voluntary movement throughout. Protective reflexes (parachute, side-saving) are working well. Babies who have been pulling to kneel will sometimes overbalance backward — this is normal and the reason close supervision near furniture is essential.',
+  },
+  cognitive: {
+    vision:
+      'Pointing behaviours begin now — extending an index finger toward something of interest. This is early intentional communication. Visual attention span is longer; they will study an interesting object for 30 seconds or more rather than moving on immediately.',
+    hearing:
+      'Imitates simple sounds you make: clicking the tongue, blowing raspberries, making animal noises. Turns toward voices in the next room. Starts to associate certain sounds with specific events (the rustle of a snack bag, the click of the car seat buckle).',
+    awareness:
+      'Cause-and-effect understanding is sophisticated now — they know that pushing a button makes something happen, and they will try the same action repeatedly and with intent. Beginning to understand simple instructions delivered with clear gesture and expression, such as "clap your hands."',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours at night, with most babies having at least one solid stretch of 5–7 hours',
+    naps: '2 naps — morning and afternoon, typically 1–1.5 hours each; total nap time around 2–3 hours',
+    notes:
+      'Teething can disrupt sleep even before a tooth is visible. If nights have become rougher without an obvious cause, check the gum line. Teething usually causes short-term disruption rather than a persistent pattern. Cold teething rings before bed, or a single age-appropriate dose of pain relief for very unsettled nights, can help.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; 3–5 tablespoons of solids per meal',
+    frequency: 'Milk 4–5 times daily; solids 1–2 times per day, working toward 2 consistent solid meals',
+    hungerCues:
+      'Opening mouth and leaning toward the spoon or food, reaching for your food or utensils, excited vocalisations at mealtime. Turning away firmly or clamping the mouth shut are clear "done" signals.',
+    notes:
+      'Lumpy textures are the goal now if you started with purees. Mashed (not blended) vegetables, well-cooked soft pasta, soft-cooked egg yolk, and small pieces of ripe banana are all good transitions. If you are doing baby-led weaning, textures should be soft enough to squash between gum and roof of mouth — no hard raw vegetables yet. Teething babies may find cold foods (chilled cucumber spear, cold yoghurt) especially welcome.',
+  },
+  play: {
+    activities: [
+      'Object transfer: hand them a toy, watch them swap it to the other hand — then offer another and see what they do',
+      'Simple sorting: two containers and a mix of blocks — they will not sort by colour yet but will enjoy putting things in and out',
+      'Imitation games: stick your tongue out, click your tongue, blow a raspberry, and wait for them to copy',
+      'Outdoor sensory play: grass under hands, sand in a small tray, or water splashing in a shallow bowl',
+    ],
+    bonding:
+      'Pointing is one of the most significant communicative developments of the first year — it shows your baby understands that you have attention, that attention can be directed, and that they can direct yours. When they point, follow their gaze and name what they are looking at. "Oh, you see the dog! That\'s a dog." This responsive naming is one of the most powerful vocabulary-building activities you can do — and it doubles as connection.',
+  },
+  parentTips: {
+    selfCare: [
+      'If teething is underway, your baby may be drooling heavily and chewing on everything. Have cold teething toys in the fridge, bib-up to protect their chest and chin from rash, and a barrier cream if the skin around the mouth is getting raw.',
+      'This is a great week to expand your solid food repertoire. New flavours are more easily accepted between 6–9 months than later — you are in a sweet spot. Be adventurous with herbs, spices (not salt), and varied textures.',
+      'Your baby\'s increasing mobility means increasing vigilance. Check that stair gates are fitted, electrical sockets are covered, and any wobbly furniture is secured. It takes 10 minutes and matters enormously.',
+    ],
+    watchFor: [
+      'Index finger pointing — proto-declarative (pointing to share interest) rather than just reaching',
+      'Smooth hand-to-hand object transfer',
+      'Imitating your sounds — tongue clicks, raspberries, simple vocalisations',
+      'Pulling to kneel at furniture, even just for a second',
+    ],
+    callDoctor: [
+      'No pincer grasp attempt (using any finger-and-thumb combination) by late in this month',
+      'No imitation of sounds or facial expressions',
+      'Persistent gagging or refusal of all textures beyond smooth purees after several weeks of offering — may indicate oral sensory sensitivity worth assessing',
+      'Signs of significant teething pain that are not manageable at home — check with your doctor about appropriate pain relief options',
+    ],
+  },
+  dailyFacts: [
+    'Pointing is a developmental milestone that often precedes first words by 1–2 months. A baby who points is showing they understand shared attention — a crucial building block for language and social development.', // Day 1
+    'Lateral incisors (the teeth either side of the front two) often begin appearing around 7–9 months. Teething order varies, but the typical sequence is: bottom front two, top front two, then the lateral incisors around them.', // Day 2
+    'Object transfer — moving a toy from one hand to the other — seems simple but requires bilateral coordination, cross-midline movement, and planning. It is a genuine motor milestone worth noticing.', // Day 3
+    'Cold foods are soothing for teething gums. Chilled cucumber sticks, cold yoghurt, or a frozen muslin cloth knot are all safe options. Numbing gels containing benzocaine are not recommended for babies.', // Day 4
+    'Babies at this age will study their own hands with deep concentration — turning them over, watching fingers move. This is self-discovery and body-mapping. It is also very entertaining to watch.', // Day 5
+    'When your baby imitates sounds back to you, respond with genuine enthusiasm — not over-the-top performance, but real delight. Authentic emotional response is more motivating for babies than exaggerated praise.', // Day 6
+    'Soft finger food for a baby this age should be soft enough to squash between your thumb and forefinger with moderate pressure. If it takes force to crush, it is not ready for your baby\'s gums — which are surprisingly effective but not yet teeth.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-30.js
+++ b/src/data/weeks/week-30.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week30 = {
   week: 30,
-  ageRange: '7 months old',
-  title: 'Week 30 — 7 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '7–8 months old',
+  title: 'Week 30 — Waving, cruising, and maybe a real word',
+  highlight:
+    'Bye-bye! Your baby may wave for the first time this week — one of those small gestures that lands like a thunderbolt. Language is on the horizon, and every babbled "mama" or "dada" might just be the real thing.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.7–9.1 kg / 17–20 lbs, ~67–71 cm / 26.5–28 in',
+    motorSkills:
+      'Many babies are crawling on hands and knees now; those still commando crawling are usually close. Pulling to stand against furniture is beginning — they grab the edge of a low table or the sofa cushion and haul themselves upright, initially wobbly and ecstatic. Cruising (taking small sideways steps while holding onto furniture) is appearing in the more advanced crawlers. Clapping hands together is a new fine motor and social skill — they love the sound and your reaction.',
+    reflexes:
+      'Fully voluntary movement. Balance reactions are developing rapidly as they practise standing — they are learning to shift weight and correct for sway. Expect a lot of sitting down hard on their padded bottom as they pull to stand and then let go.',
+  },
+  cognitive: {
+    vision:
+      'Watches with close attention from across a room. Follows a sequence of events visually — if you put something in a box and close the lid, they will watch the box even though they cannot see inside. Depth perception is adult-level.',
+    hearing:
+      'The first meaningful "mama" or "dada" may appear this week — said in the right context, to the right person. Do not be crushed if it takes longer; the range is 9–14 months for true first words. Babbling continues to grow in complexity with rising and falling intonation.',
+    awareness:
+      'Waves bye-bye, often with prompting at first and then spontaneously. Claps when pleased or in imitation. Understands "no" as a change in your tone and expression even if the concept is still abstract. Shows clear preferences for specific people, toys, and activities.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours, with one or two brief wake-ups for some babies',
+    naps: '2 naps, morning and afternoon — the 8-month growth spurt may temporarily increase overnight hunger',
+    notes:
+      'The 8-month growth spurt can bring increased appetite, clinginess, and night waking even in babies who were previously sleeping well. It typically lasts less than two weeks. Feed more generously during the day to try to front-load calories, and offer an extra milk feed before bed if they seem hungry. Hang in there — this is temporary.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; 4–6 tablespoons of solids per meal, increasing variety',
+    frequency: 'Milk 4–5 times daily; solids twice daily, aiming for three times daily by 8 months',
+    hungerCues:
+      'Reaching for your food, bouncing excitedly when the highchair appears, opening mouth eagerly for the spoon. Clear "done" signals: head turning away, mouth closed, hands batting at the spoon or bowl.',
+    notes:
+      'By now your baby should be eating from a broad range of vegetables, fruits, and protein sources. Introduce allergenic foods (peanut products, egg, wheat, dairy, fish, shellfish, sesame, tree nuts) one at a time if you have not already — current guidance recommends early introduction rather than avoidance. Wait 3 days between new allergens to identify any reaction clearly.',
+  },
+  play: {
+    activities: [
+      'Peek-a-boo behind your hands, a cloth, or a doorway — object permanence makes this genuinely funny to them now',
+      'Pull-to-stand practice: hold both hands and let them press through their feet to stand with your support',
+      'Wave practice: wave at them and say "bye-bye" at every opportunity, including waving toys, books, and animals goodbye',
+      'Simple board book reading with interactive naming: "Where\'s the dog? There\'s the dog!" Pointing together at pictures',
+    ],
+    bonding:
+      'Your baby is becoming a social creature in the fullest sense. They perform for you — waving, clapping, showing you things — because your reaction matters enormously to them. This is not just cute; it is the beginning of understanding that their actions affect other people. When you clap for their clapping, wave back at their wave, and light up at their achievements, you are confirming: "Yes, you matter. Your actions have impact. I see you." That confirmation is the foundation of confidence.',
+  },
+  parentTips: {
+    selfCare: [
+      'As your baby begins pulling to stand, low furniture becomes a hazard. Check that your coffee table has no sharp corners (use corner guards), that bookcases are wall-anchored, and that anything they might pull over onto themselves is secured.',
+      'The introduction of allergens can feel nerve-wracking. Keep an antihistamine (age-appropriate) in your home during the allergen introduction phase and know the signs of a reaction: hives, swelling, vomiting, breathing difficulty. Most reactions are mild; severe reactions are rare.',
+      'You are approaching 8 months in. If you are still finding this harder than you expected, that is honest — not a sign of failure. Many parents find this the phase where they need to reconnect with their pre-baby identity a little. Even an hour a week that is entirely yours helps.',
+    ],
+    watchFor: [
+      'Pulling to stand, even just to the knees, at furniture',
+      'Waving bye-bye, with or without prompting',
+      'Clapping hands together',
+      'First meaningful use of "mama" or "dada" in the right context (this may not come until week 35–40, so do not panic if absent)',
+    ],
+    callDoctor: [
+      'Not crawling in any form or showing interest in pulling up by 8 months',
+      'No waving, clapping, or social imitation gestures developing',
+      'A reaction to an introduced allergen: hives, swelling around the mouth, vomiting within 2 hours, or any breathing difficulty — this is an emergency',
+      'Persistent refusal of solid foods with gagging or distress at mealtimes',
+    ],
+  },
+  dailyFacts: [
+    'Waving bye-bye typically appears between 7 and 10 months. It requires understanding that gestures communicate, that other people have attention you can engage, and the motor control to perform it — all sophisticated skills packaged into one little hand flap.', // Day 1
+    'Cruising (side-stepping along furniture while holding on) is how most babies build the leg strength and balance needed for independent walking. Some babies cruise for just a few weeks; others cruise for three months before letting go.', // Day 2
+    'Clapping is a bilateral coordination skill — both hands meeting in the midline repeatedly requires significant neurological organisation. It is also irresistibly satisfying for babies, which is why they will do it constantly once they crack it.', // Day 3
+    'Early allergen introduction (peanuts, egg, tree nuts) between 4–11 months is now recommended by most paediatric bodies to reduce allergy risk, not increase it. Smooth peanut butter thinned with water or mixed into a puree is a safe starting format.', // Day 4
+    'The 8-month growth spurt is typically characterised by increased appetite, clinginess during the day, and more frequent waking at night. Unlike earlier growth spurts, babies this age may express hunger or discomfort more clearly — and loudly.', // Day 5
+    'Pulling to stand is one of the most exciting milestones for parents — and often frightening, because babies immediately try to let go. Letting them fall safely onto a padded surface is part of learning. You do not need to catch every wobble.', // Day 6
+    'When reading books, point to each picture as you name it and pause to let your baby look. The goal is not getting through the book — it is the shared attention on each image. Three pages done well beats twenty pages done quickly.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-31.js
+++ b/src/data/weeks/week-31.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week31 = {
   week: 31,
-  ageRange: '7.5 months old',
-  title: 'Week 31 — 7.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '8 months old',
+  title: 'Week 31 — 8 months and full of opinions',
+  highlight:
+    'Eight months is personality in overdrive. Your baby knows who they are, what they want, and exactly which face to make when they do not get it. Separation anxiety peaks — which is equal parts exhausting and deeply flattering.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.8–9.2 kg / 17.2–20.3 lbs, ~67–72 cm / 26.5–28.5 in',
+    motorSkills:
+      'Confident crawling in most babies — fast and purposeful. Pulling to stand independently at furniture is now reliable. Cruising (side-stepping while holding the sofa, cot rail, or table) is well underway. The pincer grip is refining toward a three-finger hold — thumb, index, and middle finger working together. In the mirror, they stare at their own reflection with genuine recognition and curiosity.',
+    reflexes:
+      'Postural control is impressive. They can stand and turn their torso, reach sideways without falling, and recover balance mid-movement. Side-saving (extending an arm to catch a sideways fall) is working well.',
+  },
+  cognitive: {
+    vision:
+      'Recognises their own reflection in a mirror and responds differently to it than to other babies — a precursor to self-recognition that will fully emerge around 18 months. Notices very small objects on the floor with alarming accuracy (dust, crumbs, tiny beads — all in the mouth).',
+    hearing:
+      'Babbling conversations are long and expressive — rising and falling tone, pauses for your response, emphatic syllables. Responds reliably to their name and to the word "no" (understood as a change in tone if not the concept). May follow simple one-word instructions when paired with gesture.',
+    awareness:
+      'Object permanence is strong — they will search for a toy hidden under two or three covers, tracking where it was put. Separation anxiety peaks around now: some babies cry at the mere sight of you picking up your bag. This is healthy attachment, not a parenting problem.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours with some variation — separation anxiety can cause more frequent night waking',
+    naps: '2 solid naps — morning nap around 9–9.30 am, afternoon nap around 1–2 pm; each typically 1–1.5 hours',
+    notes:
+      'Separation anxiety and sleep are deeply linked at this age. If your previously good sleeper is suddenly refusing to be put down or waking and screaming, anxiety is often the culprit. A consistent, warm bedtime routine — the same songs, the same sequence, the same reassuring presence — signals safety. If you do sleep training, attachment-informed approaches (checking in at intervals) tend to work well at this age without damaging the relationship.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; 5–8 tablespoons of solids per meal, growing variety',
+    frequency: 'Milk 3–4 times daily; solids 2–3 times per day — three solid meals per day is the 8-month goal',
+    hungerCues:
+      'Active engagement with the highchair — reaching for their bowl, banging the tray, vocalising loudly when food is slow. Self-feeding attempts are increasing; offer finger foods alongside spoon feeds to support this.',
+    notes:
+      'Three solid meals a day (breakfast, lunch, and dinner) alongside milk is the 8-month target. Meals do not need to be large — a few tablespoons at each is adequate. Variety matters more than volume at this stage. Iron-rich foods (red meat, fortified cereals, legumes, dark green vegetables) are particularly important now as stored iron from birth begins depleting.',
+  },
+  play: {
+    activities: [
+      'Nesting cups or stacking rings — they cannot stack yet but will nest smaller into larger with increasing success',
+      'Mirror play: make faces together, name body parts (nose, eyes, mouth) pointing at both baby and reflection',
+      'Simple turn-taking games: roll a ball to them, wait for it to come back (or go somewhere else entirely)',
+      'Cruising courses: arrange safe furniture with gaps to encourage stepping sideways from one piece to the next',
+    ],
+    bonding:
+      'Separation anxiety, as exhausting as it is, is telling you something important: you are their safe base. The world is big and strange, and you are the thing that makes it manageable. That is not dependency — it is secure attachment, and it is the precise foundation from which confident exploration later grows. When you come back every time after you leave, you teach them that the world is trustworthy. Every return matters more than you know.',
+  },
+  parentTips: {
+    selfCare: [
+      'Separation anxiety affects parents too — it can be painful to leave a crying baby even when you know they are safe and loved. Give yourself permission to leave without guilt; your baby needs you to have a self that exists outside of them.',
+      'Three solid meals a day requires more meal planning. Batch cooking — a pot of vegetable stew, some soft pasta, hard-boiled eggs, and yoghurt portions — covers most of the week with minimal daily effort.',
+      'If your baby is now standing and cruising, cot sides need to be at their lowest safe setting. Also check that there are no items in the cot that could help them climb out — bumpers, rolled blankets, toys.',
+    ],
+    watchFor: [
+      'Confident hands-and-knees crawling over varied surfaces',
+      'Pulling to stand independently without needing your hands for help',
+      'Cruising — taking sideways steps along furniture',
+      'Three-finger pincer grip developing',
+    ],
+    callDoctor: [
+      'Not pulling to any kind of stand by 9 months',
+      'No cruising or weight-bearing through legs when supported upright',
+      'Loss of previously acquired skills — particularly motor skills — always warrants prompt evaluation',
+      'Extremely limited food range that does not broaden despite consistent offering, or gagging/distress at all textures',
+    ],
+  },
+  dailyFacts: [
+    'Separation anxiety peaks between 8 and 10 months and is completely developmentally normal. It means your baby has formed a clear primary attachment and understands, now that they have object permanence, that you can leave — but not yet that you will always come back.', // Day 1
+    'The pincer grip (using thumb and forefinger to pick up small objects) is refined enough at 8 months for babies to pick up pea-sized pieces of food. This is also why the floor under the highchair needs daily attention — tiny pieces become choking hazards.', // Day 2
+    'Babies who cruise furniture are often 4–8 weeks away from independent steps. The leg strength, balance, and confidence built during cruising are the direct prerequisites for walking.', // Day 3
+    'Object permanence at 8 months means your baby will search through two hiding places for a lost toy if they saw you put it somewhere. This Piagetian "Stage 4" understanding is a significant cognitive milestone.', // Day 4
+    'Iron needs increase significantly at 6 months when stored birth iron begins to deplete. Red meat, lentils, dark leafy greens, and iron-fortified cereals all help. Pair iron-rich plant foods with vitamin C to improve absorption.', // Day 5
+    'The cot mattress should drop to the lowest setting before your baby can pull to stand. If they can already stand, this is urgent — a baby who can stand can sometimes get a leg over the rail faster than you expect.', // Day 6
+    'Three-finger pincer grip (thumb plus first two fingers) is a transitional stage on the way to the full pincer (thumb plus index finger only) that emerges closer to 9–10 months. Both are normal at 8 months.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-32.js
+++ b/src/data/weeks/week-32.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week32 = {
   week: 32,
-  ageRange: '7.5 months old',
-  title: 'Week 32 — 7.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '8 months old',
+  title: 'Week 32 — Cruising and finger foods',
+  highlight:
+    'Your baby is cruising confidently, has opinions about every bite of food, and has just discovered that pointing at something makes you bring it to them. They are running a very small but effective household.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~7.9–9.4 kg / 17.4–20.7 lbs, ~68–72 cm / 26.8–28.3 in',
+    motorSkills:
+      'Cruising is confident and increasingly fast — they hold the furniture lightly rather than gripping for dear life. Some babies are standing with just one hand for balance. Teeth are a growing reality: most babies have 1–4 visible teeth by now, usually starting with the two bottom central incisors. The index finger is extending separately from the other fingers to point and poke with precision. Imitates clapping when you clap.',
+    reflexes:
+      'Balance reactions are sophisticated. Standing babies now automatically adjust their weight when they reach sideways or bend down, rather than toppling. Falls are decreasing as balance improves.',
+  },
+  cognitive: {
+    vision:
+      'Index finger pointing is both motor and cognitive — your baby uses it to direct your attention deliberately, understanding that your gaze follows their gesture. Scans rooms for familiar faces and objects with purpose.',
+    hearing:
+      'Imitates simple clapping rhythms when you clap in a pattern. Responds to simple phrases like "where is it?" or "give me" with an action. Babbling may include longer strings of varied consonants: "babadada," "mabamama."',
+    awareness:
+      'Shows clear preferences for specific people and may show mild distress when a preferred caregiver leaves the room. Understands that objects have a "right" way up — they will turn a book around to look at it correctly. The 8-month sleep disruption is often linked to this cognitive leap.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours — the 8-month sleep disruption may be causing more waking than in recent weeks',
+    naps: '2 naps, morning and afternoon; total daytime sleep 2–3 hours',
+    notes:
+      'The 8-month sleep disruption is real and is usually driven by developmental acceleration rather than hunger or illness. Your baby\'s brain is working intensely — processing new motor skills, language, and social understanding all at once. This creates heightened arousal that bleeds into sleep. Consistent routine, a calm wind-down, and patience are the most effective tools. Avoid creating new sleep associations you are not willing to maintain long term.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; solid meals are growing in size and variety',
+    frequency: 'Milk 3–4 times daily; solids 2–3 times daily; finger foods alongside spoon feeds at every meal',
+    hungerCues:
+      'Grabbing at your food, banging the tray, vocalising loudly before the meal begins. Between meals, hunger looks like increased fussiness, mouthing objects, and seeking milk.',
+    notes:
+      'Finger foods are important at this age — not just for nutrition but for oral motor development and self-feeding confidence. Offer soft, manageable pieces at every meal: ripe banana chunks, cooked broccoli florets, soft cheese cubes, scrambled egg. The goal is to let them practise feeding themselves even if efficiency is currently zero and mess is maximum.',
+  },
+  play: {
+    activities: [
+      'Posting toys: any container with a hole to drop objects into — satisfying cause-and-effect and pincer practice',
+      'Imitation sequences: bang the table twice, wait for them to copy, then bang three times — extend the pattern',
+      'Cruising races along the sofa — stay just ahead and encourage them to follow you',
+      'Textured books: touch-and-feel pages with fabric, foil, and soft patches for tactile exploration',
+    ],
+    bonding:
+      'Your baby is showing preferences for people now in a way that is unmistakeable and sometimes socially awkward — they might refuse to be held by grandparents or push away from a well-meaning friend. Follow your baby\'s lead and do not force contact they are not comfortable with. Letting them set the pace around unfamiliar people teaches them that their sense of safety matters and that you will not override it. That lesson will serve them for a lifetime.',
+  },
+  parentTips: {
+    selfCare: [
+      'Finger food prep does not need to be complicated. Ripe banana, cooked pasta, small cheese cubes, scrambled egg, and soft-cooked vegetable pieces cover the nutritional bases with minimal preparation.',
+      'The 8-month sleep disruption is temporary — usually 2–4 weeks. If you are struggling, focus on daytime connection (which can reduce night anxiety) and be consistent with your existing bedtime routine.',
+      'Check in on your own social life. Eight months in is when many parents realise they have been in "baby bubble" mode for a long time. Even one adult social event a month makes a measurable difference to mental health.',
+    ],
+    watchFor: [
+      'Cruising confidently, perhaps with just one hand for balance',
+      'Index finger pointing — separating the finger from the others to poke, press, and direct',
+      'Imitating clapping when you clap',
+      'Showing clear preferences for specific people and familiar caregivers',
+    ],
+    callDoctor: [
+      'No cruising or pulling to stand by 9 months',
+      'No pointing gesture of any kind (index finger extension to direct attention)',
+      'Not imitating simple actions like clapping or waving',
+      'Teeth that appear discoloured or with visible damage — early dental check is worth arranging',
+    ],
+  },
+  dailyFacts: [
+    'Index finger pointing develops in two forms: proto-imperative (pointing to request something) and proto-declarative (pointing to share interest, with no specific want). Both are important — but proto-declarative pointing is particularly significant for language development.', // Day 1
+    'Babies typically get their first teeth in a predictable order: bottom two central incisors first, then top two centrals, then lateral incisors. But there is significant variation — some babies get top teeth first, some get four at once, some are 14 months before any appear.', // Day 2
+    'Finger foods before 9 months are primarily about practice, not nutrition. Babies take in very little from finger foods at first — they gum it, smear it, and drop it. The skill-building is the point. Milk remains the primary nutrition source.', // Day 3
+    'The 8-month sleep disruption differs from the 4-month regression. At 4 months, sleep architecture permanently changes. At 8 months, disruption is driven by temporary cognitive overload and separation anxiety — it is not a permanent reset of sleep structure.', // Day 4
+    'Standing with one hand for balance is a significant milestone — it shows that balance has become mostly automatic and frees up cognitive and physical resources for the next step: letting go entirely.', // Day 5
+    'Cruising teaches babies how to shift weight from one leg to the other while holding on — the exact weight-shift sequence used in walking. Every step taken while cruising is a rehearsal for independent steps.', // Day 6
+    'When a baby refuses contact with someone outside their immediate circle, they are not being naughty — they are demonstrating sophisticated social awareness. Respecting this builds trust and does not, despite grandparent anxiety, create a permanently antisocial child.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-33.js
+++ b/src/data/weeks/week-33.js
@@ -2,13 +2,77 @@
 export const week33 = {
   week: 33,
   ageRange: '8 months old',
-  title: 'Week 33 — 8 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 33 — Standing solo and following instructions',
+  highlight:
+    'A second of standing unaided. That is all it takes — arms out, wobbling, eyes wide — and then back down. But that second is the beginning of everything. Walking is coming.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.0–9.5 kg / 17.6–21 lbs, ~68–73 cm / 26.8–28.7 in',
+    motorSkills:
+      'Some babies are standing unaided for one to two seconds before sitting down or grabbing for support — the first taste of free-standing balance. Attempts to climb stairs are appearing; they can usually get up one step and stop, or try to scale anything climbable within reach. Fine pincer grip is refining — able to pick up small pieces of food with thumb and index finger. Can place objects into containers deliberately rather than just dropping them randomly. Stacking rings and nesting cups are engaging at a new level.',
+    reflexes:
+      'Fully voluntary, responsive motor control. Protective reflexes are well established in all directions. Babies at this stage often self-correct minor stumbles before anyone else registers there was a wobble.',
+  },
+  cognitive: {
+    vision:
+      'Attention is increasingly selective — they choose what to look at and ignore visual distractions that do not interest them. Will look in the correct direction when you ask "where is your cup?" if it is visible. Enjoys looking at photos of familiar people.',
+    hearing:
+      'Follows simple one-step instructions when paired with gesture: "Give me the ball" while holding out your hand. Understands "no" as a tone and may pause, look at you, and then continue the forbidden activity — which is both cognitively sophisticated and emotionally infuriating. Shakes head "no" meaningfully.',
+    awareness:
+      'Cause and effect understanding is excellent — they know that pressing this button makes that sound, that dropping the spoon gets a reaction, that shaking their head means something stops. Plays with stacking toys not just to play but to understand how things relate spatially.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours; standing in the cot can cause new wake-ups — they pull to stand and then cannot get down',
+    naps: '2 naps — morning and afternoon; combined daytime sleep around 2–2.5 hours',
+    notes:
+      'A new sleep disruption source at this age: your baby pulls to stand in the cot at night, then cannot figure out how to get down and cries for rescue. Teach the "controlled descent" during the day — how to lower themselves down from standing by bending their knees. Practise this 10–15 times during daytime play and the night-time problem usually resolves within a week.',
+  },
+  feeding: {
+    amount: '180–210 ml (6–7 oz) per milk feed; solid meals growing in variety and self-fed proportion',
+    frequency: 'Milk 3–4 times daily; three solid meals daily is the standard by now',
+    hungerCues:
+      'Reaching for specific foods they want, rejecting others by pushing away — food preferences are becoming distinct. Some babies are reducing milk intake as solid intake increases; this is normal as long as they are still having 3–4 breastfeeds or 500–600 ml of formula daily.',
+    notes:
+      'Shaking the head "no" at food is often a genuine signal of fullness or preference — and sometimes just an experiment to see what happens. Try not to show frustration or make mealtimes a battle. Offer, wait, offer again later. Pressuring babies to eat typically backfires and creates negative associations with food.',
+  },
+  play: {
+    activities: [
+      'Stacking rings: they will not stack precisely yet, but handing rings to them and watching them attempt to place them is excellent problem-solving practice',
+      'Object permanence games: hide a toy under a blanket while they watch, then ask "where is it?" — watch them find it triumphantly',
+      'Instruction-following games: "Give me the red block" — keep it simple, use gesture, and celebrate every success',
+      'Safe stair climbing with close supervision: one or two steps up and back down, building the body awareness and motor skill for safe stair navigation',
+    ],
+    bonding:
+      'Your baby shaking their head "no" is a developmental triumph even when it drives you mad. They are using their body to communicate, understanding that they can influence outcomes, and beginning to assert their own preferences as separate from yours. This is the very beginning of healthy autonomy. The toddler years will be easier if you start respecting those "no" moments now — not every preference can be accommodated, but being heard matters enormously.',
+  },
+  parentTips: {
+    selfCare: [
+      'Teach the controlled descent from standing during playtime this week. Kneel behind them at the sofa, place their hands on the surface, bend their knees gently, and guide them to sitting. Repeat many times. This skill prevents a significant new source of night waking.',
+      'Stair gates are now truly essential — downstairs, upstairs, and anywhere there is a vertical drop. Babies at this stage move toward stairs with alarming speed and no sense of danger.',
+      'If three solid meals a day feels overwhelming, build a simple rotating meal framework: batch-cook protein (egg, lentils, meat) and vegetables on Sundays, and combine differently across the week. Variety does not require daily cooking from scratch.',
+    ],
+    watchFor: [
+      'Standing unaided for even one second — this is the precursor to walking',
+      'Deliberately placing objects into containers (not just dropping)',
+      'Following a one-step instruction paired with gesture',
+      'Shaking head "no" meaningfully in response to unwanted things',
+    ],
+    callDoctor: [
+      'Not pulling to stand at all by 9 months',
+      'No response to simple instructions or clear gesture-based communication',
+      'Significant clumsiness in one side of the body compared to the other — asymmetry in motor skills warrants assessment',
+      'Persistent gagging or complete refusal of all finger foods after several weeks of offering',
+    ],
+  },
+  dailyFacts: [
+    'The first moment of standing unaided is usually very brief — one or two seconds before the baby sits down deliberately or grabs for support. This is not a failure; it is the beginning of building the balance threshold needed for longer stands.', // Day 1
+    'Babies who pull to stand in the cot and then cry because they cannot get down have not "forgotten" how to sit — they have not yet developed the controlled reverse movement. Bending at the knees to lower down safely is a distinct skill from pulling up.', // Day 2
+    'Shaking the head "no" typically appears before the word "no" is spoken. Babies learn the gesture from watching you shake your head in response to their actions, then adopt it as their own communication tool.', // Day 3
+    'The stacking ring toy has been around for decades because it works. It teaches object permanence (where did the smaller ring go?), cause-and-effect, spatial reasoning, and fine motor precision — all in one simple toy.', // Day 4
+    '"Give me" instruction-following requires the baby to hear the words, understand the intent, locate the object, physically retrieve it, and hand it over — a remarkable chain of cognitive and motor steps for an 8-month-old.', // Day 5
+    'Cause-and-effect play at this age is sometimes repetitive in ways that test adult patience. A baby who drops the same object 30 times is running an experiment with a sample size of 30. The repetition is the learning.', // Day 6
+    'At 8 months, a baby\'s understanding of "no" is tone-and-expression-based, not language-based. They pause because your voice and face changed, not because they have processed the word semantically. True comprehension of "no" as a concept comes closer to 12 months.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-34.js
+++ b/src/data/weeks/week-34.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week34 = {
   week: 34,
-  ageRange: '8 months old',
-  title: 'Week 34 — 8 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '8–9 months old',
+  title: 'Week 34 — Nearly 9 months and studying everything',
+  highlight:
+    'Your baby examines objects like a scientist — turning them over, passing them between hands, pressing every surface. Their hands are instruments of genuine inquiry. The world is a lab and they are running every experiment.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.1–9.6 kg / 17.9–21.2 lbs, ~68–73 cm / 26.8–28.7 in',
+    motorSkills:
+      'Standing steadily while holding furniture with relaxed grip. Cruising sideways is quick and purposeful — they plan a route along the furniture and execute it. Index finger pointing is well established and used constantly to direct attention and investigate objects. Begins to use both hands to examine a single object — one holds it steady while the other touches, taps, or peels at it. Imitating facial expressions (opening mouth wide, pursing lips, raising eyebrows) is developing.',
+    reflexes:
+      'Balance is mature enough that brief unsupported standing is more common. Protective reflexes are automatic. Hands are becoming precision instruments rather than blunt tools.',
+  },
+  cognitive: {
+    vision:
+      'Visual examination of objects is detailed and sustained — they will rotate and inspect a new toy for 60 seconds or more. Imitates simple actions they observe: patting a doll, pushing a toy car. Understands that pictures in books represent real things.',
+    hearing:
+      'Starting to understand "no" in context — may pause before doing a forbidden thing and look at you as if checking. Responds to their name from across the room consistently. Babbling includes clear intonational patterns that sound like questions, commands, and statements.',
+    awareness:
+      'Imitates facial expressions with intent — if you stick your tongue out, they may copy after a delay, not just immediately. Understands sequences of events and anticipates steps: seeing you get the bib means food is coming, seeing the bath towel means bath time. This predictability is reassuring to them.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '9–11 hours; most babies at this age have one, possibly two, brief night wakings',
+    naps: '2 naps, morning and afternoon; some babies are starting to show signs that the morning nap is shortening',
+    notes:
+      'Approach to 9 months often brings more settled sleep if the 8-month regression is behind you. However, any developmental leap, illness, or change in routine can temporarily disrupt even a good sleeper. The foundations you have built — consistent routine, safe sleep environment, your own calm presence at bedtime — are what carry you through the disruptions.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per milk feed as solids increase; solid meals of 5–8 tablespoons',
+    frequency: 'Milk 3–4 times daily; three solid meals daily with finger foods at each',
+    hungerCues:
+      'Strong food preferences are emerging — they may push away certain textures or colours while clearly reaching for favourites. This is normal. Exposure over time, not pressure in the moment, is the way through food refusal.',
+    notes:
+      'Finger foods with more texture — soft-cooked broccoli that still has a little bite, pasta with sauces, soft-cooked chicken strips — are appropriate now. Babies this age benefit from handling their food before eating it: squishing, smearing, and examining are all part of the sensory learning that makes them comfortable with varied textures. Accept the mess.',
+  },
+  play: {
+    activities: [
+      'Object examination tray: a few unfamiliar objects with different textures, weights, and sounds — let them investigate fully without redirection',
+      'Simple pretend play: feed a spoon to a toy animal, hand a cup to a doll, and see if your baby imitates',
+      'Facial expression imitation: make exaggerated faces slowly and wait — they may copy after several seconds',
+      'Naming body parts on themselves: "Where is your nose?" and guide their hand to touch it — repetition builds the knowledge',
+    ],
+    bonding:
+      'Babies this age watch your face for emotional information constantly — this is called social referencing and it is at its most intense now. When they encounter something new, they look to you: is this safe? Is this interesting? Is this funny or scary? Your calm, curious face is the most powerful reassurance you can give. You are teaching them how to approach novelty — and your attitude toward the world shapes theirs more profoundly than any toy.',
+  },
+  parentTips: {
+    selfCare: [
+      'If your baby is examining every tiny object on the floor with their mouth, do a thorough sweep of your home for small items at floor level. Coins, button batteries, small toy parts, and even some food pieces (grapes, cherry tomatoes, whole nuts) are genuine hazards.',
+      'Button batteries (the flat, round ones in remote controls and small electronics) are a serious and life-threatening hazard for babies this age. Tape shut any battery compartments that are accessible, and store or discard any loose button batteries immediately.',
+      'You are approaching the 9-month check-up. Use it — ask every question you have been storing up. Your GP or health visitor cannot help with things they do not know are on your mind.',
+    ],
+    watchFor: [
+      'Standing steadily at furniture with a relaxed rather than white-knuckle grip',
+      'Using both hands together to examine a single object',
+      'Imitating facial expressions and simple actions (patting, pushing)',
+      'Beginning to understand "no" — pausing before repeating a forbidden action',
+    ],
+    callDoctor: [
+      'Not standing or bearing weight through legs when held upright by 9 months',
+      'No imitation of facial expressions or simple gestures',
+      'Persistent one-sidedness in reaching, grasping, or weight-bearing — arms or legs noticeably weaker on one side',
+      'Any difficulty swallowing or persistent drooling beyond the teething amount — worth checking if it seems disproportionate',
+    ],
+  },
+  dailyFacts: [
+    'Social referencing — looking to a caregiver\'s face to gauge how to feel about a new situation — peaks in intensity between 8 and 12 months. Studies show that babies who receive calm, curious facial feedback from caregivers approach novel objects more confidently.', // Day 1
+    'Button batteries are one of the most serious small-object hazards for babies and toddlers. If swallowed, they can cause severe internal burns within 2 hours. Treat any suspected swallowing as a medical emergency.', // Day 2
+    'Imitating actions after a delay — not immediately, but minutes or even hours later — is called deferred imitation and is a sign of strong working memory. Your baby is storing what they see and replaying it.', // Day 3
+    'The 9-month check-up (sometimes done at 8–10 months) typically assesses sitting, crawling, standing, babbling, social engagement, and early communication. It is also a good time to discuss weaning progress, iron intake, and sleep.', // Day 4
+    'Sequence anticipation — knowing that seeing the bib means food, or the car seat means going out — shows sophisticated temporal reasoning. Your baby is mapping cause-and-effect across time, not just in the immediate moment.', // Day 5
+    'Babies this age often protest when an interesting object is taken away, but will usually be distracted within 30–60 seconds by something else of interest. This is a good window to redirect — much shorter than the toddler protests to come.', // Day 6
+    'Pretend play in its earliest form appears around 8–9 months: a baby who "feeds" a toy, or puts a phone to their ear in imitation, is demonstrating that they understand objects can represent other things and that actions have social meaning.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-35.js
+++ b/src/data/weeks/week-35.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week35 = {
   week: 35,
-  ageRange: '8.5 months old',
-  title: 'Week 35 — 8.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '9 months old',
+  title: 'Week 35 — 9 months: the check-up milestone',
+  highlight:
+    'Nine months. They have been outside as long as they were inside. Your baby understands several words, waves consistently, and a few might even take their first tottering independent steps this week.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.2–9.7 kg / 18–21.4 lbs, ~69–74 cm / 27–29 in',
+    motorSkills:
+      'Cruising is confident and fast — they navigate across the full length of a sofa without hesitation. Standing independently for several seconds is becoming more frequent. Some babies — the early walkers — take their first independent steps around now, though the range is 9–15 months. Pincer grip is increasingly refined. Three teeth is typical around 9 months, though range is 0–6 teeth and all within normal. Waves bye-bye consistently and without prompting.',
+    reflexes:
+      'Balance reactions are automatic and effective. Free-standing balance, when it occurs, is a result of the vestibular and proprioceptive systems coming online together. Falls are becoming more controlled — babies this age begin to crouch and lower themselves rather than toppling.',
+  },
+  cognitive: {
+    vision:
+      'Points at pictures in books to show you things, not just to request. Visual attention to details is refined enough that they notice a small change in a familiar room. Enjoys looking at photographs of family members and vocalises in recognition.',
+    hearing:
+      'Understands several words beyond their name: common nouns ("cup," "ball," "dog"), and key social words ("bye-bye," "no," "up"). Responds to simple questions when paired with gesture — "Do you want more?" — with a clear physical response.',
+    awareness:
+      'Proto-declarative pointing (pointing to share interest, not request) is consistent and frequent — a major predictor of language development. Waves bye-bye reliably in context. May wave hello as well. Shows empathy-adjacent responses: looking concerned when someone cries, or subdued in a tense atmosphere.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '10–11 hours at night for many babies; settling times are usually shorter now that routines are established',
+    naps: '2 naps — morning nap typically 45–75 minutes, afternoon nap 1–1.5 hours; combined daytime sleep around 2–2.5 hours',
+    notes:
+      'Sleep is often more settled at 9 months than it was at 8. Routines that have been running for months are deeply embedded — your baby knows what is coming at bedtime and that knowledge is calming. If nights are still significantly disrupted, the 9-month check-up is a good opportunity to discuss sleep with your healthcare provider.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per milk feed; three solid meals plus possibly a snack',
+    frequency: 'Milk 3–4 times daily (500–600 ml formula total or 3–4 breastfeeds); solids three times daily',
+    hungerCues:
+      'Very clear food preferences are established. Some babies wave away whole food categories (orange vegetables, anything green) while eating others with gusto. Continue offering disliked foods alongside accepted ones — repeated exposure across weeks matters more than any single meal.',
+    notes:
+      'A healthy 9-month diet includes protein (meat, fish, egg, legumes) at least once daily, iron-rich foods, dairy (full-fat yoghurt, cheese), a range of vegetables and fruit, and some starchy carbohydrates. Water in a cup from meals onwards is recommended — offer it at every meal even if they do not drink much yet.',
+  },
+  play: {
+    activities: [
+      'First-steps practice: stand them against the sofa, step back slightly, and encourage them to walk the gap toward you with arms outstretched',
+      'Simple shape sorters: the round hole only, to begin with — problem-solving with immediate satisfying feedback',
+      'Name-the-picture books: "Where is the cat?" Point together and name everything on the page',
+      'Clapping songs and action rhymes: "Pat-a-cake," "Round and Round the Garden" — gesture + language + touch',
+    ],
+    bonding:
+      'The 9-month check-up is not just about ticking developmental boxes — it is a chance to step back and see how far you have all come. Three months ago your baby could barely sit unsupported. Now they are cruising furniture, waving at strangers, and pointing at dogs. You did that with them. The work of showing up every day — the feeds, the floor time, the songs, the exhausted middle-of-the-night resettlings — is visible in this person who has emerged. Take a moment to actually feel that.',
+  },
+  parentTips: {
+    selfCare: [
+      'Attend the 9-month check-up with a list of anything you want to discuss: feeding, sleep, development, any concerns. Write it down beforehand — you will forget in the moment otherwise.',
+      'Walking is coming. Baby shoes are not necessary until they are walking outdoors — bare feet or soft socks are better for indoor walking development. When you do buy shoes, have them properly fitted.',
+      'If your baby is walking or close to it, check that the furniture they are cruising along cannot tip forward. Bookshelves, TV stands, and tall storage units all need to be anchored to walls before independent steps arrive.',
+    ],
+    watchFor: [
+      'Consistent, unprompted waving bye-bye',
+      'Proto-declarative pointing — pointing to share interest, not just request',
+      'Standing independently for several seconds',
+      'Responding to several familiar words in context',
+    ],
+    callDoctor: [
+      'Not crawling in any form or not bearing weight through legs by 9 months',
+      'No pointing gesture of any kind — this is one of the most important red flags for language and social development',
+      'No waving or social gestures',
+      'At the 9-month check-up, raise any concerns about eating, sleep, vision, hearing, or development — that is what it is for',
+    ],
+  },
+  dailyFacts: [
+    'At 9 months, your baby has been outside the womb exactly as long as they were inside. The transformation in that time — from a being who could only cry and feed to one who laughs, waves, points, and crawls — is one of the most remarkable developmental explosions in human biology.', // Day 1
+    'Proto-declarative pointing (pointing to share something, not to request it) is one of the strongest early predictors of vocabulary size at 18 months. When your baby points at a bird and looks at you, they are practising shared attention — the foundation of all communication.', // Day 2
+    'The 9-month check-up typically looks for: sitting without support, pulling to stand, pincer grasp, babbling, social smile, stranger wariness, object permanence, and response to name. All of these reflect the neurological maturation happening across multiple brain systems simultaneously.', // Day 3
+    'Some babies walk at 9 months; most walk between 11 and 14 months. Walking before 9 months is rare but normal. Not walking at 18 months is worth evaluation. Everything in between is a completely normal range.', // Day 4
+    'Bare feet are better than shoes for early walkers indoors — they allow the foot to spread, grip, and receive sensory feedback from the floor, all of which contribute to balance and proprioception. Socks with grips are a reasonable alternative on slippery floors.', // Day 5
+    'Water in a cup from 6 months onwards is recommended alongside meals. Most 9-month-olds do not drink much — they are not thirsty in the way adults are, and their primary fluid comes from milk. But the habit of having water available builds the association for later.', // Day 6
+    'Clapping songs and action rhymes (Itsy Bitsy Spider, Pat-a-cake, Row Your Boat) combine gesture, rhythm, language, and social engagement simultaneously. They are some of the most neurologically rich activities available to a 9-month-old — and they require nothing more than your hands and your voice.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-36.js
+++ b/src/data/weeks/week-36.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week36 = {
   week: 36,
-  ageRange: '8.5 months old',
-  title: 'Week 36 — 8.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '9 months old',
+  title: 'Week 36 — Pulling up everywhere, babbling with intent',
+  highlight:
+    'Your baby will now pull to stand on literally anything — you, the dog, the laundry basket. Gravity is a minor inconvenience. And their babble is starting to sound uncannily like it means something.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.3–9.8 kg / 18.3–21.6 lbs, ~69–74 cm / 27.2–29.1 in',
+    motorSkills:
+      'Pulls to stand on any available surface — furniture, walls, people, anything at hand height. Steps confidently sideways along everything. Many babies stand without support for several seconds with good balance before lowering back down deliberately. Using both hands purposefully and independently — one hand holds, the other manipulates. Stacks rings with increasing success. Controlled descent from standing (knees bending to sit) is becoming more reliable.',
+    reflexes:
+      'Fully mature protective reflexes in all directions. Falls are increasingly managed rather than accidental — babies often grab as they go down or catch themselves on one hand. Balance recovery after a sway is largely automatic.',
+  },
+  cognitive: {
+    vision:
+      'Can follow a pointing finger and look at the object being indicated — this requires understanding that the finger is a referential gesture, not an interesting object in itself. This typically develops around 9 months and is a significant social-cognitive milestone.',
+    hearing:
+      'Babbling has clear intent — different sounds are used consistently in similar contexts, which is the beginning of word development. A recognisable first word — "mama," "dada," "baba," "no," or a specific sound for a specific thing — appears for some babies this week.',
+    awareness:
+      'Engages in back-and-forth games with sustained attention — peek-a-boo, rolling a ball, taking turns making sounds. Understanding that they have caused your response, and that you will respond to their action, is fully internalised. Solid foods now happen 2–3 times daily as a clear expectation rather than an experiment.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '10–11 hours; the period between settling and the first wake-up is often the longest stretch',
+    naps: '2 naps — morning around 9–9.30 am, afternoon around 12.30–1.30 pm; most babies sleep 1–1.5 hours per nap',
+    notes:
+      'Night sleep is often fairly settled now if developmental disruptions have passed. The main cause of new night waking at this stage is illness (common — older siblings, nursery, winter), teething, and separation anxiety flares. Your established routine is your anchor through all of these.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per milk feed; solid meals are growing in size and texture complexity',
+    frequency: 'Milk 3–4 times daily; three solid meals plus possibly a small morning or afternoon snack',
+    hungerCues:
+      'Clearly communicates food desire — reaching for your plate, pointing at the fridge or cupboard, excited noises when the highchair appears. May also signal fullness by clamping mouth shut, turning away persistently, or throwing food.',
+    notes:
+      'A small, nutritious snack between meals can help maintain energy levels without affecting appetite for main meals — ripe fruit, rice cakes with a scrape of nut butter, yoghurt, or soft cubes of cheese. Avoid snacks within an hour of a main meal.',
+  },
+  play: {
+    activities: [
+      'Stacking rings: sit behind them and guide the ring onto the post, then celebrate — over many sessions they will start doing it independently',
+      'Walk-behind push toy: a sturdy cart or push-along toy they can hold and walk — excellent for building walking confidence',
+      'Babbling conversation: respond to their babble as if it is a real sentence — "Oh really? Then what happened?" — this models conversational turn-taking',
+      'Bath play with cups and pouring: filling and emptying containers, pouring water between them — endlessly engaging sensory and causal learning',
+    ],
+    bonding:
+      'A first recognisable word — whenever it arrives — is one of the most electrifying moments in early parenting. Whether it is "mama" said to you, "ba" for ball, or "dog" as an approximate sound for every animal, the moment you realise your baby is using a specific sound to mean a specific thing is unforgettable. When it happens, write it down. Tell someone. That is the beginning of the conversation you will have for the rest of your lives together.',
+  },
+  parentTips: {
+    selfCare: [
+      'Pull-to-stand is happening on everything now. Check the stability of everything at your baby\'s reach height: bookshelves must be wall-anchored, TV units secured, freestanding lamps removed or relocated. Also check that plants are non-toxic — babies grab those too.',
+      'The walk-behind push toy is one of the most developmentally valuable investments at this stage — if you do not have one, a laundry basket or a cardboard box filled with books provides the same function.',
+      'If you have not yet arranged a dentist visit, now is a good time. Most guidelines recommend a first dental check around when the first tooth appears, or by 12 months at the latest. Early visits are usually brief and positive.',
+    ],
+    watchFor: [
+      'Standing without support for several seconds with controlled descent',
+      'Following a pointing finger to look at the indicated object',
+      'First recognisable word — any consistent sound used for a specific referent',
+      'Back-and-forth play with sustained attention across multiple turns',
+    ],
+    callDoctor: [
+      'Not pulling to stand or bearing weight through legs by now',
+      'Not following a pointing gesture to look at the indicated object — this is a key social-cognitive milestone',
+      'Loss of any previously established skill — motor, language, or social',
+      'Signs of ear infection (tugging at ear, fever, unusual fussiness, disrupted sleep) — common at this age and treatable',
+    ],
+  },
+  dailyFacts: [
+    'Following a pointing finger — understanding that the finger is indicating something elsewhere rather than being an interesting object in itself — requires "joint attention": the ability to share a focus of attention with another person. It typically emerges between 9 and 12 months.', // Day 1
+    'First words often do not sound like the adult version of the word. "Ba" for ball, "da" for dog, "muh" for more — all count as first words if they are used consistently and intentionally for the same referent. The meaning matters, not the pronunciation.', // Day 2
+    'Babies pulling to stand on unstable objects (laundry baskets, toy boxes) is an injury risk. The object tips when they pull on the edge. Keep an eye on what they are choosing as their standing target and remove any genuinely unstable options.', // Day 3
+    'Solid foods at three meals daily is the goal by 9 months. The reason is nutritional: at 6 months, stored birth iron begins depleting and breast milk alone does not provide enough. Three varied solid meals across the day address multiple nutritional needs simultaneously.', // Day 4
+    'Bath time is peak sensory play time. Pouring water from cup to cup, submerging and floating toys, splashing with hands — every bath interaction is building understanding of volume, gravity, and cause-and-effect in a medium babies universally enjoy.', // Day 5
+    'The first dental check around 12 months is worth doing even if no teeth have appeared yet — the dentist can advise on oral hygiene for the gums, check the jaw and palate, and make the dental environment a familiar rather than frightening place from early on.', // Day 6
+    'Babies this age are entering a period where snacks make more sense nutritionally. Three meals plus 1–2 snacks maintains more even blood sugar than three meals alone — particularly relevant if your baby wakes early from naps or is becoming cranky between meals.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-37.js
+++ b/src/data/weeks/week-37.js
@@ -2,13 +2,77 @@
 export const week37 = {
   week: 37,
   ageRange: '9 months old',
-  title: 'Week 37 — 9 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 37 — First steps with hands held',
+  highlight:
+    'Walking with your hands — one small hand gripping each of yours as they step forward with enormous concentration — is one of the great small joys of the first year. They are almost there.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.4–9.9 kg / 18.5–21.8 lbs, ~70–74 cm / 27.5–29 in',
+    motorSkills:
+      'Many babies are now taking several steps while holding both hands held out in front — hand-held walking is common. Some are already walking independently; most are still 2–6 weeks away from it. The 9-month growth spurt may be adding a little weight and length this week. Dropping a held toy deliberately to pick up a new one shows sophisticated motor planning — they have to coordinate releasing, tracking the dropped item, and reaching for the new one.',
+    reflexes:
+      'Fully mature. Walking while hand-held requires active balance correction with every step — your baby is doing significant neurological work even though it looks effortless from the outside.',
+  },
+  cognitive: {
+    vision:
+      'Points at objects of desire from across the room — not just nearby. Visual field tracking has developed to the point where they can follow a moving object\'s path and predict where it is going. Interested in books from the adult reading position rather than always trying to eat them.',
+    hearing:
+      '"Mama" and "dada" are now clearly attached to the correct people for many babies — they will call you specifically, not just babble the sounds. May have one or two additional consistent word-sounds. Responds to simple two-word phrases in context: "Come here," "All gone."',
+    awareness:
+      'Shows early empathy: if a sibling or adult cries, many babies this age will look distressed, offer a toy, or pat the person gently. This is a significant social-emotional milestone — they have a model of other people having feelings, and a response to those feelings. Point to desired objects consistently to show rather than just request.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '10–11 hours; the 9-month growth spurt may briefly increase night hunger',
+    naps: '2 naps — morning and afternoon; combined daytime sleep usually 2–2.5 hours',
+    notes:
+      'The 9-month growth spurt can bring a temporary increase in appetite and more frequent waking. An extra milk feed before bed, or a slightly larger solid dinner, can help front-load calories and reduce night hunger. The disruption usually lasts less than two weeks.',
+  },
+  feeding: {
+    amount: '150–180 ml (5–6 oz) per milk feed; solid meals are growing — some babies this age eat surprisingly large portions',
+    frequency: 'Milk 3–4 times daily; three solid meals plus a snack if needed',
+    hungerCues:
+      'Very vocal and physical hunger signals now — pointing at food, reaching toward the kitchen, saying a sound for "eat" or "more." Clear "done" signals too: throwing food is often (not always) a fullness signal rather than wilful naughtiness.',
+    notes:
+      'Food throwing is developmentally normal at this age and tends to escalate between 9–18 months. Rather than reacting with attention (which is rewarding), remove the food or bowl calmly and matter-of-factly. "Food stays on the tray" is a sentence you will say approximately 4,000 times over the next year.',
+  },
+  play: {
+    activities: [
+      'Hand-held walking: hold both hands slightly above their head height and take a slow walk across the room — let them set the pace',
+      'Ball rolling and chasing: a soft ball rolled gently across the floor that they can crawl after and retrieve',
+      'Empathy play: when a toy "falls down," express gentle concern — "Oh no, the bear fell! Are you okay, bear?" — watch for your baby\'s response',
+      'Sorting by shape: simple two-shape sorters are appropriate now — rounds and squares only, with clear instruction and demonstration',
+    ],
+    bonding:
+      'Walking hand-in-hand with your baby — even when they are gripping your fingers and you are bent double — is its own kind of connection. There is trust in those small hands holding yours: trust that you will not let them fall, that you are moving through the world together, that this enormous new thing is safe because you are there. When they take those hands away and walk alone, they will carry that same confidence with them.',
+  },
+  parentTips: {
+    selfCare: [
+      'Hand-held walking means a lot of bent-over walking for you. Your back will thank you if you get down to their level on your knees or sit behind them on the floor — you can still guide their hands without crouching for long periods.',
+      'The food-throwing phase is beginning. Establishing a calm, consistent boundary now — "food stays on the tray" and removing it without drama when thrown — lays the groundwork. There is no shortcut; it just takes consistent repetition over months.',
+      'The 9-month growth spurt coinciding with the approach to 10 months means your baby may seem perpetually hungry for a couple of weeks. Increase meal portions and snacks rather than increasing milk, which is the right balance shift at this age.',
+    ],
+    watchFor: [
+      'Walking while holding both hands — several steps in a row with good weight transfer',
+      '"Mama" and "dada" clearly attached to the correct person',
+      'Dropping one toy to pick up another deliberately',
+      'Showing early empathy responses — concern, offering a toy, patting when someone is upset',
+    ],
+    callDoctor: [
+      'Not pulling to stand or not cruising at all by 9–10 months',
+      'No consistent use of "mama" or "dada" attached to specific people by 12 months (watchlist from now)',
+      'No pointing, waving, or social gestures by 10 months',
+      'Persistent difficulty with solids despite weeks of offering — worth a referral to check for oral motor or sensory issues',
+    ],
+  },
+  dailyFacts: [
+    'Walking while holding both hands typically precedes independent walking by 2–6 weeks. During hand-held walking, the baby is doing most of the balance work — your hands provide psychological reassurance more than physical support. A gentle loosening of your grip now and then lets you gauge how much they actually need you.', // Day 1
+    'Early empathy responses (looking distressed when another cries, offering a toy to comfort) emerge around 9–10 months and reflect the development of a "theory of mind" — an understanding that other people have inner states. This capacity continues developing until around age 4.', // Day 2
+    'The 9-month growth spurt is often less dramatic than earlier ones in terms of visible weight gain — babies\' growth rate is slowing from its infancy peak. But increased appetite, clinginess, and sleep disruption are still common indicators.', // Day 3
+    'Food throwing is most common when a baby is full, bored at the table, or seeking a reaction. The reaction-seeking motivation means that dramatic responses (even negative ones) can reinforce the behaviour. Matter-of-fact removal of food is more effective than any emotional response.', // Day 4
+    '"Mama" and "dada" becoming person-specific is a huge milestone — it marks the transition from babbling (sounds without referents) to true words (sounds attached to specific meanings). Some babies make this transition at 8 months; others not until 12–14 months. The timing does not predict later language ability.', // Day 5
+    'Crawling remains the preferred mode of fast transport for most babies even after they begin walking. Walking is effortful and slow at first; crawling is efficient. Most babies use both for months after taking first steps.', // Day 6
+    'A ball that rolls away and has to be retrieved is perfect motivation for a pre-walker. It creates a clear goal (get the ball), provides a destination, and rewards arrival with a satisfying tactile object. Simple, effective, and it costs nothing.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-38.js
+++ b/src/data/weeks/week-38.js
@@ -1,14 +1,78 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week38 = {
   week: 38,
-  ageRange: '9 months old',
-  title: 'Week 38 — 9 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '9–10 months old',
+  title: 'Week 38 — Approaching 10 months, first solo steps',
+  highlight:
+    'Some babies take their first truly independent steps this week — a moment that stops your heart. Even if yours is not there yet, they are closer than they have ever been. Crawling remains their superpower.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.5–10.0 kg / 18.7–22 lbs, ~70–75 cm / 27.6–29.5 in',
+    motorSkills:
+      'Some babies take 2–4 independent steps now — usually between two pieces of furniture, or between furniture and a standing parent, with a step-and-plop landing. Crawling is still fast and efficient and most babies default to it for speed. Self-feeding with fingers is becoming skilled — smaller pieces, more accurate mouth delivery. Sippy and straw cups are being used with increasing competence. Up to 4–6 teeth may be visible. Repeats sounds or actions that get a positive reaction.',
+    reflexes:
+      'The walking reflex present at birth was suppressed months ago; the walking happening now is entirely voluntary and cortically controlled. Balance is the final frontier — most babies standing alone can hold it for 5–10 seconds before sitting deliberately or toppling.',
+  },
+  cognitive: {
+    vision:
+      'Visual tracking of fast-moving objects is adult-level. Points at things in books with clear purpose. Looks at pictures in a book from the correct orientation and shows preference for familiar subjects (animals, babies, faces).',
+    hearing:
+      'Repeats sounds or words that get a laugh or strong reaction — this is deliberate performance. May have 2–4 consistent word-sounds used meaningfully. Responds to "no" in genuine understanding for some actions — pauses, considers, sometimes desists.',
+    awareness:
+      'Claps hands when pleased with themselves — not just in imitation of you, but spontaneously after achieving something. May have 4–6 teeth by now, and teething discomfort is a common source of disrupted sleep and fussiness. Recognises objects by function: holds a phone to their ear, tries to use a spoon.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '10–11 hours; learning to walk often causes brief sleep disruption as the brain processes new motor programs overnight',
+    naps: '2 naps, morning and afternoon — combined daytime sleep 2–2.5 hours; some babies begin resisting the morning nap around this time',
+    notes:
+      'Pre-walking and new walking often cause a brief sleep disruption — your baby\'s brain is processing and consolidating new motor programs during sleep, which increases arousal. This typically passes within 1–2 weeks of the new skill becoming more automatic. Stick to your routine and avoid introducing new sleep props that create long-term dependence.',
+  },
+  feeding: {
+    amount: '120–180 ml (4–6 oz) per milk feed as solid intake increases; three solid meals and possibly 1–2 snacks',
+    frequency: 'Milk 3 times daily for formula-fed babies (500–600 ml total); breastfed babies may feed 3–4 times; solids three times daily',
+    hungerCues:
+      'Points at food, reaches toward cupboards, makes sounds for "more" or "eat." Between meals, shows hunger through increased fussiness, mouthing objects, and seeking snacks.',
+    notes:
+      'Self-feeding with fingers is a priority now — offer pieces of food your baby can pick up independently at every meal, even if a spoon is also used. The hand-to-mouth coordination, the fine motor practice, and the sense of control are all developmentally valuable. Spoon refusal is common at this age; offering a second spoon for them to hold while you use another is a practical solution.',
+  },
+  play: {
+    activities: [
+      'First steps encouragement: stand a small distance from them — arms outstretched — and call them to you; gradually increase the gap as confidence grows',
+      'Clapping games with songs: "If You\'re Happy and You Know It," clapping along to music they enjoy',
+      'Simple pretend play: give them a toy phone, a spoon and bowl, or a toy brush — watch them use objects appropriately',
+      'Straw cup mastery: practise drinking through a straw; it builds the oral motor strength and control that also aids speech development',
+    ],
+    bonding:
+      'Watching your baby take their first independent steps — truly alone — is an experience that is hard to prepare for. You will probably cry, or laugh, or do both. However it lands emotionally, know that what you are seeing is the product of nine months of consistent support: the floor time, the pulling-up practice, the held hands across a hundred rooms. Independence does not happen despite connection — it grows from it.',
+  },
+  parentTips: {
+    selfCare: [
+      'If your baby is walking or nearly walking, the entire ground floor of your home needs reassessment. Think about corners, drop heights, items that can be pulled, hot surfaces (oven, fireplace), and anything within low reach. A mobile baby is an exponentially more capable one.',
+      'Spoon refusal at this age is common and rarely means the end of spoon feeding — it usually means your baby wants more control. Offering two spoons (one to hold, one to eat with) and allowing them to dip and attempt feeding themselves reduces the battle significantly.',
+      'With approaching 10 months, you may notice your own energy and mood shifting as the relentlessness of the first year starts to feel cumulative. If you are struggling, say so — to your partner, your GP, a friend. Perinatal mental health support is available well beyond the newborn period.',
+    ],
+    watchFor: [
+      'First truly independent steps — even 2–3 before sitting down',
+      'Self-clapping when pleased — spontaneous, not just imitative',
+      'Using objects by function (phone to ear, spoon to bowl)',
+      'Sippy or straw cup use becoming reliable',
+    ],
+    callDoctor: [
+      'Still not pulling to stand or cruising by now — this is worth discussing at a check-up',
+      'Not using any consistent intentional word-sounds by 10 months',
+      'No clapping, pointing, or waving — absence of social gestures at this stage warrants evaluation',
+      'Signs of ear infection (which can affect balance and cause unusual falls): fever, ear-tugging, irritability, sudden increase in night waking',
+    ],
+  },
+  dailyFacts: [
+    'First independent steps almost always happen near a transition point — between furniture, between parent and furniture, or across a very small gap. Babies instinctively minimise the unguided distance at first. The gap grows wider over days as confidence builds.', // Day 1
+    'Clapping spontaneously when pleased with themselves shows self-evaluation — your baby has a sense of achievement and an emotional response to it. This self-referential awareness is the beginning of healthy self-esteem.', // Day 2
+    'Using a straw cup (rather than a tipped sippy cup) requires active sucking rather than passive tilting, which builds the same oral motor muscles used in speech production. Speech-language therapists generally prefer straw cups for this reason.', // Day 3
+    'When babies learn a major new skill — walking, crawling, pulling to stand — they often practise it during sleep, causing brief arousal and sometimes full waking. This motor consolidation during sleep is a feature, not a bug: the brain is actually doing necessary work.', // Day 4
+    'Functional object use (phone to ear, brush to hair) shows your baby is building a model of the social world — they know what things are for and what people do with them. This early pretend play is a significant cognitive achievement.', // Day 5
+    'At 9–10 months, formula-fed babies typically need around 500–600 ml of formula daily alongside solids. Below that, monitor for sufficient calorie intake; significantly above it may crowd out solid food intake. The balance is shifting, and that is exactly right.', // Day 6
+    'Teething at 9–10 months usually involves the upper central incisors (if not already through) and the lateral incisors beginning. More teeth in the mouth also means more food can be processed — this often coincides with babies handling a broader range of textures.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-39.js
+++ b/src/data/weeks/week-39.js
@@ -1,14 +1,79 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week39 = {
   week: 39,
-  ageRange: '9.5 months old',
-  title: 'Week 39 — 9.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '9–10 months old',
+  title: 'Week 39 — Almost 10 months',
+  highlight:
+    'Ten months is just around the corner. Your baby is standing, cruising, pointing, and performing. They have figured out that they can make you laugh — and they will do it on purpose.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: '~8.5–10.0 kg / 18.7–22 lbs, ~70–75 cm / 27.6–29.5 in',
+    motorSkills:
+      'Standing confidently while holding furniture, releasing one hand to reach for objects. Many babies take 1–3 independent steps this week — usually between two surfaces, landing with a plop. Crawling is still the preferred speed mode. Pincer grip is refined — index finger and thumb working together for small pieces of food. Stacks two objects deliberately. Puts objects into containers and tips them out again.',
+    reflexes:
+      'All primitive newborn reflexes are long gone. Movement is entirely voluntary and increasingly purposeful. Balance responses (adjusting weight, reaching to steady themselves) are growing more sophisticated every day.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention is highly selective — babies this age choose what to look at and ignore the rest. Points an index finger to indicate things of interest. Follows a point across a room and looks at what you are pointing to, not just your finger — a significant cognitive step.',
+    hearing:
+      'Understands 10–20 words even if they can only say 1–4. Responds to their own name immediately. Turns toward familiar voices in a crowded room. Shows recognition when familiar songs begin — may attempt to "sing" along with rhythm changes.',
+    awareness:
+      'Object permanence is fully established — actively searches for hidden objects in multiple locations. Shows empathy: may bring a toy to a crying adult or sibling. Understands cause and effect deeply and tests it constantly. Knows that other people have intentions and will try to redirect yours.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day',
+    nightSleep: '10–12 hours, usually one longer stretch with a possible brief waking',
+    naps: '2 naps — a longer morning nap (1–1.5 hrs) and a shorter afternoon nap (45–60 min)',
+    notes:
+      'Sleep is generally more settled than the disruptions of 8–9 months for most babies. If you are still seeing multiple night wakings, it is likely habit-based rather than developmental necessity — this is a good window to gently address overnight feeding or settling if it has become unsustainable. The transition to one nap is still months away for most babies — resist dropping the morning nap prematurely.',
+  },
+  feeding: {
+    amount: '180–240 ml (6–8 oz) per milk feed; 3 solid meals per day',
+    frequency: '3–4 milk feeds per day alongside 3 solid meals',
+    hungerCues:
+      'Reaching toward food, opening mouth, leaning forward in high chair. Disinterest, turning head away, or pushing food away are reliable "done" signals — do not push past them.',
+    notes:
+      'Solids are now contributing meaningfully to nutrition — not just tasting. Offer a wide range of textures including soft lumps, strips for self-feeding, and family foods modified for age. Cow\'s milk as a main drink is still not recommended until 12 months, but dairy products (cheese, yoghurt) are fine. Iron-rich foods remain important at every meal.',
+  },
+  play: {
+    activities: [
+      'Cruising challenges: place interesting toys along the sofa at intervals so they have a reason to side-step toward them',
+      'Container play: a box of safe household objects (wooden spoon, silicone spatula, stacking cups) for in-out-tip-repeat play',
+      'Pointing games: point to pictures in a book and name them, then wait — some babies will begin to point back',
+      'Chase on the floor: crawl after them with sound effects — builds speed, coordination, and absolute delight',
+      'Simple shape sorters: even just getting the shape to the hole is a satisfying problem-solving win',
+    ],
+    bonding:
+      'Your baby now has a fully formed sense of humour. They repeat things that make you laugh. They initiate games. They look at your face when something surprising happens to check your reaction — called social referencing — and they use your expression to decide how to feel about it. That is not small. That is one of the most sophisticated social behaviours in the animal kingdom, and your ten-month-old is already doing it.',
+  },
+  parentTips: {
+    selfCare: [
+      'Ten months in — you have been parenting for nearly a year. Take a moment to notice how much you know now: the cues, the rhythms, what works for your specific baby. You earned all of that.',
+      'If you are returning to or already back at work, this stage often brings a second wave of guilt or exhaustion as mobility increases. Childcare transitions at 9–10 months can be hard due to separation anxiety — extra goodbye rituals and consistency help both of you.',
+      'Sleep-training, if you have not yet addressed night waking and it is affecting you, is well within the developmental window. Evidence-based approaches (graduated extinction, sleep fading, camping out) all have good outcomes at this age.',
+    ],
+    watchFor: [
+      'Independent standing without holding on, even for a second or two',
+      'Pointing with index finger at things of interest or to direct your attention',
+      'Clearly searching for a hidden object in multiple places (not just where they last saw it)',
+      'Using 1–2 words consistently with clear, appropriate meaning',
+    ],
+    callDoctor: [
+      'Not pulling to stand or showing no interest in weight-bearing on legs',
+      'No gestures at all — no waving, pointing, or reaching to be picked up',
+      'Lost skills that were previously present (regression in motor or social abilities)',
+      'No babbling or consonant sounds at this age',
+    ],
+  },
+  dailyFacts: [
+    'Your baby\'s pincer grip — picking up small objects with index finger and thumb — is one of the most distinctly human motor skills. It\'s appearing right now, and it\'s the same grip that lets humans use tools, write, and play instruments.', // Day 1
+    'Social referencing is in full swing: your baby looks at your face after something surprising happens to see how you react before deciding how to feel. Your calm face in new situations genuinely helps them feel safe.', // Day 2
+    'The gap between what your baby understands and what they can say is huge right now — most 9-month-olds understand 10–20 words but can only reliably say 1–4. Comprehension is miles ahead of production.', // Day 3
+    'Babies this age test limits not out of defiance but out of curiosity — they\'re learning cause and effect socially. When you say "no" and mean it, and when you say "no" and let it slide, they are cataloguing the difference.', // Day 4
+    'Separation anxiety peaks between 9 and 12 months. It\'s a sign of healthy attachment — your baby understands you are the most important person and doesn\'t yet grasp that you reliably come back. Consistent, calm goodbyes shorten the distress window.', // Day 5
+    'Cruising — side-stepping along furniture — builds the hip abductor and stabiliser muscles your baby needs for walking. Every metre they cruise is strength training for the moment they let go.', // Day 6
+    'The first independent steps usually happen between furniture pieces or between furniture and a person, and are followed by a deliberate sit-plop landing. If yours hasn\'t happened yet, it is coming — the range for first steps is 9–15 months.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-40.js
+++ b/src/data/weeks/week-40.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week40 = {
   week: 40,
-  ageRange: '9.5 months old',
-  title: 'Week 40 — 9.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '10 months old',
+  title: 'Week 40 — Ten months and counting',
+  highlight:
+    'The first birthday is in sight, and your baby knows it — not literally, but their confidence and curiosity have never been higher. They are exploring their world with intent, and that intent is unmistakable.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.0–9.5 kg / 20–21 lbs and ~72–74 cm / 28–29 in. Growth is steady but slower than those early explosive months — your baby is burning more energy moving than growing.',
+    motorSkills:
+      'Many babies are walking with one hand held and crawling fast when they want to cover ground quickly. Pulling to stand is effortless, cruising along furniture is smooth. Stacking 2 blocks with deliberate placement is a new fine motor achievement. Pincer grip is refined enough to pick up small finger foods with ease.',
+    reflexes:
+      'Primitive reflexes are long gone. All movements are intentional and purposeful. Balance reactions are maturing — your baby instinctively catches themselves when they start to topple.',
+  },
+  cognitive: {
+    vision:
+      'Vision is essentially adult-quality now. Your baby tracks fast-moving objects, spots familiar people across the room, and notices tiny details on objects and pages. They will point at something small they have spotted before you even see it.',
+    hearing:
+      'Your baby distinguishes not just words but tone and intent. A stern "no" stops them in their tracks. An enthusiastic "yes!" sends them into a wiggling celebration. They are reading emotional content in sound.',
+    awareness:
+      '"Mama" and "dada" are said with clear meaning — this is not babble, it is communication. Your baby follows simple instructions paired with a gesture (e.g. "give it to me" with an outstretched hand). Object permanence is solid: they search actively for hidden objects and remember where you put something even after a short delay.',
+  },
+  sleep: {
+    totalHours: '13–15 hours/day total',
+    nightSleep: '10–12 hours, typically with no feeds for most babies',
+    naps: '2 naps (morning ~45–60 min, afternoon ~60–90 min), though some babies are starting to fight the morning nap as they approach 1 year',
+    notes:
+      'A 10-month sleep regression is real and common — it often coincides with pulling to stand and the urge to practise new skills. If your baby is waking and standing in the cot, resist going in immediately. Give them a few minutes to resettle on their own.',
+  },
+  feeding: {
+    amount: 'Formula or breast milk: ~500–600 ml / 17–20 oz per day alongside three solid meals and 1–2 snacks',
+    frequency: '3 main solid meals plus snacks. Milk feeds: 3–4 per day (morning, after naps, bedtime)',
+    hungerCues:
+      'Reaching for food, leaning toward the spoon, opening mouth in anticipation, pointing at food. Turning head away, closing mouth, or pushing food away are clear "done" signals — respect them.',
+    notes:
+      'Finger foods should be the star of the show now. Offer a variety of textures and flavours at every meal. Self-feeding builds motor skills and food confidence simultaneously. Mess is not optional — it is developmentally necessary.',
+  },
+  play: {
+    activities: [
+      'Block stacking: offer 4–6 soft blocks and encourage your baby to stack and knock them down — the destruction is as satisfying as the building',
+      'Pointing games: point to things and name them, then pause and see if they point back. This back-and-forth is a core building block of communication',
+      'Container play: a box and a set of objects to put in and take out occupies most 10-month-olds for a surprisingly long time',
+      'Supported walking practice: hold one hand and walk together around the house, narrating what you pass — this builds confidence and vocabulary simultaneously',
+    ],
+    bonding:
+      'Your baby now uses you as a "social reference" — they look to your face when they encounter something new or uncertain to gauge whether it is safe. When you smile and nod, they proceed. When you look alarmed, they stop. This is called social referencing and it is a profound sign of trust. Use it consciously: your calm signals safety.',
+  },
+  parentTips: {
+    selfCare: [
+      'At 10 months, many parents are feeling the cumulative exhaustion of nearly a year of interrupted sleep and constant vigilance. Acknowledge that this is a marathon, not a sprint — and it is nearly done.',
+      'Find one thing that is yours this week — a podcast on a walk, 20 minutes of reading, a phone call with a friend — something that reminds you that you exist outside of parenthood.',
+      'If you are back at work, guilt about time away is normal. The quality of your presence when you are there matters far more than the hours.',
+    ],
+    watchFor: [
+      '"Mama" and "dada" said with clear meaning for specific people — this is a genuine language milestone',
+      'Pointing with the index finger to show you things of interest — this "proto-declarative pointing" is a major social-cognitive leap',
+      'Following simple instructions with a gesture — shows comprehension is well ahead of expression',
+    ],
+    callDoctor: [
+      'No purposeful communication (no "mama/dada" with meaning, no pointing, no waving or gesturing) by 10 months — mention this at the next check-up',
+      'Persistent falling or inability to bear weight on legs when supported — worth checking',
+      'Significant regression in skills that were previously established — always worth a conversation with your doctor',
+    ],
+  },
+  dailyFacts: [
+    'Your baby\'s brain at 10 months has already formed over 1 trillion synaptic connections — roughly twice as many as an adult brain. The "pruning" of unused connections begins and continues for years.', // Day 1
+    'Pointing is one of the most significant cognitive milestones of the first year. It requires your baby to understand that other people have different viewpoints and can be directed to share yours.', // Day 2
+    'Self-feeding finger foods isn\'t just about nutrition — the hand-eye coordination and fine motor control required is intense cognitive and physical work. Every messy meal is a learning session.', // Day 3
+    'The 10-month sleep regression often coincides with the drive to stand and cruise. Your baby\'s brain is so busy consolidating new motor skills that it wakes them up. It typically passes in 2–4 weeks.', // Day 4
+    '"Social referencing" — looking to your face in uncertain situations — begins in earnest around 10 months. Babies use your emotional reaction as a guide to how they should feel about something new.', // Day 5
+    'Your baby now understands object permanence fully. If they see you hide a toy under a cup, they will look for it there — and under the other cups too if you try to fool them. Memory is working.', // Day 6
+    'At 10 months, your baby can distinguish between about 70–100 different sounds in their native language and has already begun filtering out sounds from languages they haven\'t heard regularly.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-41.js
+++ b/src/data/weeks/week-41.js
@@ -2,13 +2,75 @@
 export const week41 = {
   week: 41,
   ageRange: '10 months old',
-  title: 'Week 41 — 10 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 41 — Standing on their own terms',
+  highlight:
+    'Your baby can now stand independently for seconds at a time — and the look on their face when they realise it is pure, astonished pride. Walking is coming, and you can both feel it.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.0–9.5 kg / 20–21 lbs and ~72–74 cm / 28–29 in. Weight gain has slowed to roughly 85–140 g / 3–5 oz per week — normal and expected at this stage.',
+    motorSkills:
+      'Walking with two hands held is comfortable and confident. Many babies stand independently for 5–10 seconds before sitting down carefully. Cruising along furniture is fast and fluid. Teeth count is typically 4–8, and first molars may be beginning to emerge — extra drooling and fussiness are common.',
+    reflexes:
+      'Protective stepping reflex is strong — when lowered toward a surface feet-first, legs extend to make contact. Balance reactions in all directions are steadily maturing, which is exactly what makes walking possible.',
+  },
+  cognitive: {
+    vision:
+      'Your baby notices and points at distant objects — a bird outside the window, a person down the hall. Depth perception is mature, which supports growing confidence navigating steps and changes in surface level.',
+    hearing:
+      'Receptive language runs well ahead of expressive language. Your baby understands their name, "no", "up", "bye-bye", and many more words they cannot yet say back. The comprehension is genuinely impressive even when the speech is not.',
+    awareness:
+      'Imitation is a major feature of this week. Your baby watches what you do and copies it — clapping hands, waving, banging on a surface. This is not mindless mimicry; it is how they learn that actions have purpose and that they can affect the world.',
+  },
+  sleep: {
+    totalHours: '13–15 hours/day total',
+    nightSleep: '10–12 hours. Some babies experience increased night waking as the drive to stand and practise new motor skills disrupts sleep',
+    naps: '2 naps: morning (~45–60 min) and afternoon (~60–90 min). Total daytime sleep ~2–3 hours',
+    notes:
+      'If your baby is pulling to stand in the cot and cannot get back down, teach them to lower themselves slowly during the day. This single skill resolves many night wakings — they get stuck standing and panic rather than being unable to resettle.',
+  },
+  feeding: {
+    amount: 'Breast milk or formula: ~480–600 ml / 16–20 oz per day alongside substantial solid meals',
+    frequency: '3 solid meals, 1–2 snacks, 3–4 milk feeds. Cup drinking is established — offer water with every meal',
+    hungerCues:
+      'Excitement and reaching when food appears; opening mouth proactively. Satiety cues: turning head, closing mouth firmly, trying to push the food away or hand it back to you.',
+    notes:
+      'Repetitive routines at mealtimes — the same song, the same approach with the spoon — give your baby something to anticipate and participate in. Predictability at meals reduces resistance and increases intake.',
+  },
+  play: {
+    activities: [
+      'Clapping songs: "If You\'re Happy and You Know It" or any song with clapping — babies this age cannot resist joining in once they have the motor skill',
+      'Furniture cruising obstacle course: arrange safe furniture with small gaps so your baby has to reach for the next piece — builds balance and problem-solving simultaneously',
+      'Cup stacking and nesting: plastic cups that stack or nest inside each other offer size-sorting learning and very satisfying destruction',
+      'Ball rolling back and forth: the earliest form of turn-taking, which underpins all social interaction and later conversation',
+    ],
+    bonding:
+      'Repetitive games — doing the exact same thing over and over — are not boring to your baby, they are deeply satisfying. Predictability builds trust, and mastery builds confidence. When your baby initiates the same game for the fifth time in a row, they are asking you to confirm that the world is reliable and that you are too.',
+  },
+  parentTips: {
+    selfCare: [
+      'Baby-proofing reaches maximum urgency now. Spend 20 minutes getting down to your baby\'s eye level and looking for hazards you have missed — cords, sharp corners, accessible cupboards.',
+      'If you are experiencing "touched out" feelings — an aversion to physical contact after a long day of holding and feeding — this is a recognised phenomenon and not a character flaw. Name it to your partner.',
+      'The upcoming birthday can bring unexpected emotions: pride, grief at how fast it has gone, reflection on the whole year. Give yourself space to feel all of it.',
+    ],
+    watchFor: [
+      'Independent standing for even 2–5 seconds — a clear pre-walking milestone',
+      'Deliberate imitation of actions you perform, beyond just facial expressions',
+      'Responding consistently to their own name and at least 2–3 other familiar words',
+    ],
+    callDoctor: [
+      'Unable to pull to stand or bear weight on legs at all by 10–11 months — worth discussing at the next visit',
+      'No imitation of actions (waving, clapping, banging) by this age',
+      'Signs of ear infection: pulling at ears, high fever, unusual crying, or disrupted sleep following a cold',
+    ],
+  },
+  dailyFacts: [
+    'Babies who cruise along furniture are often just weeks away from independent steps. The same muscles, balance systems, and neural pathways are being refined every time they side-step along the sofa.', // Day 1
+    'Cup drinking at this age works best with a small open cup or a straw cup. Sippy cups with hard spouts can interfere with oral motor development — the straw cup is a better transition tool toward independent drinking.', // Day 2
+    'When a baby who was sleeping well suddenly starts waking again, a new motor milestone is almost always involved. The brain is so busy processing new skills that it wakes them up at night to keep practising.', // Day 3
+    'Imitation is the brain\'s most efficient learning mechanism. When your baby watches you bang a drum and then tries it themselves, they are running a full cognitive simulation: observing, predicting, executing, and comparing results to expectations.', // Day 4
+    'Your baby\'s vocabulary comprehension at 10 months is typically 20–50 words, while their spoken vocabulary may still be just 1–3 words. Understanding always runs far ahead of speaking throughout the first two years.', // Day 5
+    'Games with a predictable structure — peek-a-boo, clapping songs, "round and round the garden" — do serious cognitive work. Your baby is learning sequences, anticipating outcomes, and experiencing the pleasure of accurate prediction.', // Day 6
+    'Babies given some autonomy over feeding — which finger food to pick up, how much they eat — show better appetite regulation and less food refusal. Offering choice at mealtimes, even small choices, genuinely helps.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-42.js
+++ b/src/data/weeks/week-42.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week42 = {
   week: 42,
-  ageRange: '10 months old',
-  title: 'Week 42 — 10 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '10–11 months old',
+  title: 'Week 42 — First steps may be coming',
+  highlight:
+    'Some babies take their first independent steps this week — wobbly, glorious, and completely unexpected until the moment it happens. Whether yours does or not, the groundwork is all there.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.0–9.5 kg / 20–21 lbs and ~73–75 cm / 28.5–29.5 in. Head circumference is roughly 45–46 cm / 17.5–18 in, reflecting continued healthy brain growth.',
+    motorSkills:
+      'Some babies take their first independent steps this week — most do not yet, and both are normal. Standing without support is improving daily. Throwing objects is a new feature: your baby picks something up and flings it, then watches it fall. This is not aggression — it is physics exploration and motor development. Also new: using objects correctly, like holding a toy phone to their ear or brushing hair with a toy brush.',
+    reflexes:
+      'Balance reactions are mature enough for brief independent standing. Protective extension (putting hands out to catch a fall) is well established, which is why falls from standing rarely result in injury.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention is increasingly deliberate. Your baby scans a room systematically, notices something of interest, and moves toward it with a clear goal in mind. This goal-directed behaviour is a major cognitive leap.',
+    hearing:
+      'Your baby knows 2–3 words with meaning, understands many more, and is beginning to point to body parts when you name them. "Where is your nose?" said with a friendly tone will often get a tentative finger to the face.',
+    awareness:
+      'Attachment to a transitional object — a specific blanket, stuffed animal, or comfort item — is strong now. This is healthy and important. The object represents security and helps your baby self-regulate when you are not immediately available. Do not dismiss or replace it.',
+  },
+  sleep: {
+    totalHours: '13–15 hours/day total',
+    nightSleep: '10–12 hours. Babies practising new motor skills may wake to "practise" in the cot — this is temporary',
+    naps: '2 naps totalling 2–3 hours. Some babies are beginning to resist the morning nap as they approach 11 months',
+    notes:
+      'If your baby has a transitional object (lovey), make sure it is always available for sleep. A second identical one kept in reserve is worth considering — losing the one and only comfort object at bedtime is genuinely difficult for everyone.',
+  },
+  feeding: {
+    amount: 'Breast milk or formula: ~480–600 ml / 16–20 oz per day. Solid food intake is increasing and now provides a substantial portion of daily nutrition',
+    frequency: '3 solid meals, 1–2 snacks, 3–4 milk feeds. Offer water in a cup freely throughout the day',
+    hungerCues:
+      'Clear interest in what others are eating; reaching for food on your plate; signing "more" if you have taught it. Refusal cues: turning away, pushing spoon or food, becoming upset when the meal continues after they have clearly signalled done.',
+    notes:
+      'Introducing a wider variety of textures and flavours now pays dividends for months. Babies who experience more variety before 12 months tend to be more accepting eaters after 12 months when food preferences start to narrow.',
+  },
+  play: {
+    activities: [
+      'Object-in-container play: a container with a hole large enough to post items through, or a simple shape sorter — builds spatial reasoning and problem-solving',
+      'Telephone play: hold a toy phone to your ear, say "hello", then pass it to your baby and see if they put it to their ear. This "functional play" is an early form of symbolic understanding',
+      'Throwing and fetching: roll a soft ball or let your baby throw an object — then pick it up and hand it back. The anticipation of the "fetch" and the cause-and-effect are deeply engaging',
+      'Naming body parts: "where is your tummy?" said playfully during dressing or bath time is vocabulary building disguised as routine',
+    ],
+    bonding:
+      'Your baby is now building a mental model of you — not just who you are when you are present, but who you are when you are absent. Consistent, predictable responses to their cues is what shapes that model as safe and secure. You do not need to be perfect. You need to be reliably yourself.',
+  },
+  parentTips: {
+    selfCare: [
+      'If first steps happen this week, the impulse to grab your phone and film every moment is real — but some of your best memories will be from the times you put the phone down and just were there.',
+      'Throwing behaviour can be exhausting and seemingly endless. Reframe it: your baby is doing motor and physics experiments. Soft objects only, and a patient but clear "we throw soft things" repeated calmly is enough for now.',
+      'Sleep this week may be disrupted by the motor surge. If you can, plan to be a bit more flexible with bedtime to accommodate a later wind-down if your baby has been particularly active.',
+    ],
+    watchFor: [
+      'Using objects functionally — phone to ear, brush to hair, spoon toward mouth — this is early symbolic understanding',
+      'Pointing to body parts when named, even tentatively',
+      'Strong attachment to one specific comfort object, which is healthy and normal',
+    ],
+    callDoctor: [
+      'No single meaningful word at all by 11 months — worth discussing at the next visit',
+      'No use of gestures (pointing, waving, reaching up to be lifted) by this age',
+      'Any loss of skills that were previously present — always worth immediate follow-up',
+    ],
+  },
+  dailyFacts: [
+    'The first independent steps typically happen between 9 and 12 months, with 12–13 months being the statistical average. Walking at 9 months or 14 months can both be completely normal — the range is wide.', // Day 1
+    'Throwing objects is one of the earliest scientific experiments a baby conducts: hypothesis (if I let go, it falls), method (releasing grip), observation (it falls), conclusion (gravity is consistent). This is physics.', // Day 2
+    'Transitional objects — a blanket or soft toy — serve a genuine developmental function. They help babies practise self-regulation and manage the stress of separation. Research shows children with comfort objects are not more anxious; if anything, they cope better.', // Day 3
+    'Functional play (using objects as they are intended — a brush to brush hair, a cup to drink from) emerges around 10–11 months and is a precursor to full symbolic play, where one object represents another entirely.', // Day 4
+    'Your baby\'s pincer grip is now refined enough to pick up a single pea or grain of rice. The fine motor control required for this took ten months of neural development to achieve.', // Day 5
+    'Babies at this age understand the concept of "inside" — they will search inside containers for hidden objects. This is a significant spatial reasoning milestone that emerges from months of watching, playing, and exploring.', // Day 6
+    'Around 10–11 months, many babies develop a strong preference for familiar foods while becoming more suspicious of new ones. This "food neophobia" is evolutionary — it protected mobile babies from eating unknown plants. Offering new foods alongside familiar ones, without pressure, is the most effective approach.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-43.js
+++ b/src/data/weeks/week-43.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week43 = {
   week: 43,
-  ageRange: '10.5 months old',
-  title: 'Week 43 — 10.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '11 months old',
+  title: 'Week 43 — Eleven months',
+  highlight:
+    'One month to go. Your baby is a walker in waiting — or maybe already walking — and a communicator who understands far more than they can say. The personality you are watching emerge right now is the one they will carry for life.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.2–9.7 kg / 20–21.5 lbs and ~73–75 cm / 28.5–29.5 in. Growth rate is around 1–1.5 cm / 0.5 in per month at this stage.',
+    motorSkills:
+      'Many babies are walking independently or extremely close — a few steps between objects is a common pattern. Stacking 3 or more blocks with concentration and deliberate placement is new. Putting objects into and taking them out of containers remains endlessly fascinating. The pincer grip is precise and confident.',
+    reflexes:
+      'Balance and righting reactions are mature. When your baby trips or starts to fall, protective responses kick in automatically. Falls from standing height are common but rarely result in more than a surprise.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention to pictures is more sustained now. Your baby will look at simple illustrations in board books and appear to recognise familiar images. Pointing at pictures is beginning.',
+    hearing:
+      'Two to three clear words with consistent meaning are typical. "Mama", "dada", and one or two others — "uh-oh", "more", "dog" — said reliably for the right referent. Understands many more words than they say: up to 50 or more words comprehended.',
+    awareness:
+      'Points purposefully and persistently to get your attention toward things they want or find interesting. Shows clear affection — hugging, leaning in, patting — toward familiar people. Understands "give it to me" and will often comply (and sometimes pointedly not comply, which is equally cognitively sophisticated).',
+  },
+  sleep: {
+    totalHours: '13–14 hours/day total',
+    nightSleep: '10–12 hours. Night waking, if it occurs, is most often brief and linked to developmental activity or teething',
+    naps: '2 naps totalling 2–3 hours. Some 11-month-olds are beginning to fight the morning nap — if so, move it slightly later rather than dropping it yet',
+    notes:
+      'At 11 months, solid food is now the main source of nutrition. Keep a consistent bedtime routine — bath, feed, book, bed in the same sequence every night. Predictability is deeply regulating for babies this age.',
+  },
+  feeding: {
+    amount: 'Solid foods are now the nutritional foundation. Breast milk or formula: ~400–500 ml / 14–17 oz per day alongside three full meals',
+    frequency: '3 solid meals plus 1–2 snacks. Milk feeds: 3 per day (morning, after afternoon nap, bedtime)',
+    hungerCues:
+      'Interest in what you are eating, reaching for the table, pointing at food. Self-feeding with fingers is the main mode — spoon practice is beginning but still largely exploratory.',
+    notes:
+      'Now is a good time to start introducing foods from all your family\'s regular meals — texture and flavour variety at 11 months builds the eating adaptability you want at 2, 3, and 5 years.',
+  },
+  play: {
+    activities: [
+      'Block towers of 3+: stack them together, then let your baby knock them down — building and demolishing teaches cause-and-effect and spatial reasoning',
+      'Simple board book reading with pointing: "where is the dog?" and waiting for them to point — even a vague gesture counts and should be celebrated',
+      'Posting games: any toy or household container that accepts objects through a hole — posting and retrieving is concentrated fine motor and spatial work',
+      'Imitation games: pretend to feed a doll or stuffed animal and hand the spoon to your baby to try — early symbolic and social play beginning',
+    ],
+    bonding:
+      'Your baby now seeks physical affection proactively — they crawl to you for a hug, lean their head against you, pat your face. Receiving this affection fully, putting down what you are doing to be present for it, sends a message that their love is welcome and returned. These moments are brief and matter enormously.',
+  },
+  parentTips: {
+    selfCare: [
+      'Birthday planning is probably happening — try to make it about your family and your baby, not about meeting anyone else\'s expectations. A tired parent at a simple gathering is better than an exhausted parent at an elaborate party.',
+      'Separation anxiety may be peaking around 11 months. Maintain consistent goodbyes — always say goodbye even if it is hard, and keep departures calm and brief. Sneaking away backfires.',
+      'Take a photo or video this week with no agenda — just your baby being themselves. You will want it later.',
+    ],
+    watchFor: [
+      '2–3 clear words used consistently and correctly',
+      'Walking independently or between two pieces of furniture with 3–5 steps',
+      'Showing affection proactively — hugging, leaning, patting familiar people',
+    ],
+    callDoctor: [
+      'No words at all, not even "mama" or "dada" with meaning, by 11 months',
+      'Not using gestures (pointing, waving, raising arms to be picked up) by this age',
+      'Significant asymmetry in how your baby uses their two hands — strong consistent preference for one side can occasionally signal something worth checking',
+    ],
+  },
+  dailyFacts: [
+    'At 11 months, your baby understands the concept of "sharing" at a basic level — they can hand you an object when asked. This is not yet genuine altruism, but it is the first step toward it.', // Day 1
+    'The word "mama" or "dada" said with consistent specific meaning marks the transition from babble to true language — a categorically different cognitive achievement. It means your baby has mapped a sound to a concept and uses it reliably.', // Day 2
+    'Block stacking requires your baby to calculate height, balance, and the relationship between the size of blocks — all without any conscious awareness that they are doing geometry.', // Day 3
+    'Around 11 months, many babies begin pointing declaratively — not to get something, but simply to share attention ("look at that!"). This "joint attention" is one of the strongest predictors of language development.', // Day 4
+    'Separation anxiety typically peaks between 9 and 18 months. It is a sign of healthy attachment, not insecurity. Babies who are most distressed at separation often settle fastest once the parent is out of sight.', // Day 5
+    'Your baby\'s memory at 11 months extends to several weeks. They will remember specific people, places, songs, and routines across gaps of days. This is why consistency in routines pays off — they remember what is supposed to happen next.', // Day 6
+    'The 11-month mark is a good time to review the home environment: stair gates, outlet covers, cupboard locks, and heavy furniture anchored to walls. A newly mobile baby has access to hazards they could not reach two months ago.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-44.js
+++ b/src/data/weeks/week-44.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week44 = {
   week: 44,
-  ageRange: '10.5 months old',
-  title: 'Week 44 — 10.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '11 months old',
+  title: 'Week 44 — Walking and talking, day by day',
+  highlight:
+    'If your baby is walking, you can see it improving daily — better balance, wider turns, longer stretches. If they are not yet, they are watching and storing everything, and it will come. Either way, they have opinions, and they are not shy about sharing them.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.2–9.7 kg / 20–21.5 lbs and ~73–75 cm / 28.5–29.5 in. An 11-month growth spurt may cause a temporary increase in appetite and some overnight height gain.',
+    motorSkills:
+      'Walking is improving day by day — a wider stance provides balance, and your baby is beginning to learn to turn, stop, and carry objects while upright. Loves to carry things while walking: a toy in each hand, a book, anything within reach. Fine motor control is strong — turning pages, picking up small objects, fitting items into containers.',
+    reflexes:
+      'Equilibrium responses are refined enough that most falls are caught by the hands. Your baby is becoming a physically confident explorer, which means they will attempt things that make you nervous.',
+  },
+  cognitive: {
+    vision:
+      'Picture recognition in books is clear — your baby looks at a picture of a dog and looks toward your dog, or makes a dog sound. Connecting representations to real-world objects is a huge conceptual milestone.',
+    hearing:
+      'Vocabulary is growing: 2–5 clear words typical, with understanding far exceeding that. "No" head shake is now used purposefully — not just a movement, but a deliberate communication. Waves bye-bye independently at the right moment.',
+    awareness:
+      'Your baby uses the head shake for "no" with clear communicative intent, which is an important milestone — it means they have a way to refuse and decline. This is the beginning of self-advocacy and should be treated with respect even when inconvenient.',
+  },
+  sleep: {
+    totalHours: '13–14 hours/day total',
+    nightSleep: '10–12 hours. If a growth spurt is happening, your baby may wake hungry once overnight — a brief feed is fine and appropriate',
+    naps: '2 naps: morning (~30–45 min) and afternoon (~60–90 min). The morning nap may be shortening as the transition to one nap approaches',
+    notes:
+      'If your baby is fighting the morning nap hard, try pushing it 15–30 minutes later rather than dropping it. A very overtired 11-month-old makes the afternoon nap and bedtime significantly harder.',
+  },
+  feeding: {
+    amount: 'Solid foods are the main event. Breast milk or formula: ~360–480 ml / 12–16 oz per day. Do not be alarmed if milk intake has dropped — this is expected and appropriate',
+    frequency: '3 solid meals plus 1–2 snacks. Expanding the texture range is the main goal this month — soft lumps, soft cooked pieces, different crunch levels',
+    hungerCues:
+      'Pointing at food, reaching toward the table, excited vocalisations at meal setup. Full cues: leaning back, turning away, handing food back, becoming distracted from the meal entirely.',
+    notes:
+      'Finger foods of expanding texture are important now. By 12 months your baby should be eating soft pieces of most family foods. Each new texture introduced before the first birthday reduces food aversion risk afterward.',
+  },
+  play: {
+    activities: [
+      'Walking carrying games: give your baby a lightweight object to carry while they walk — a small stuffed animal, a soft block — this improves balance and coordination significantly',
+      'Bye-bye practice: wave at people, at toys going back in a box, at the duck going down the drain at bath time — anywhere the gesture is meaningful and in context',
+      'Shape sorting: simple 3-shape sorters are within reach now for many babies. The trial-and-error problem-solving is intense and rewarding',
+      'Dancing: hold your baby\'s hands and sway, or let them bounce independently to music — movement to rhythm is joyful and supports vestibular development',
+    ],
+    bonding:
+      'Your baby now communicates "no" clearly, and this matters more than it might seem. When you honour their refusals — not force food they have pushed away, not push an activity they have clearly rejected — you teach them that their communication has power. This is foundational for consent and self-advocacy later. You can still set limits while honouring no.',
+  },
+  parentTips: {
+    selfCare: [
+      'The lead-up to the first birthday can feel like a lot of competing demands — party planning, milestone anxiety, developmental checklists. Your baby does not need a party. They need you, consistent and present.',
+      'If you are formula feeding and dreading the transition to cow\'s milk at 12 months, start introducing small amounts mixed into food now to familiarise the taste and check for tolerance.',
+      'You are one month away from the most significant parenting milestone of the first year. Let yourself feel the magnitude of that.',
+    ],
+    watchFor: [
+      'Deliberate "no" head shake used to refuse or decline — a communication milestone',
+      'Waving bye-bye spontaneously at appropriate moments (not just when prompted)',
+      'Carrying objects while walking — shows balance and coordination advancing',
+    ],
+    callDoctor: [
+      'Any fever above 38.5°C / 101.3°F lasting more than 2 days — check for ear infection or other source',
+      'Strong consistent hand preference before 12 months — worth mentioning to your doctor as it can occasionally be significant',
+      'Complete loss of appetite lasting more than 3–4 days outside of obvious illness — worth a check',
+    ],
+  },
+  dailyFacts: [
+    'Babies who walk earlier do not have an intellectual advantage over those who walk later. Motor milestones vary widely and are determined largely by temperament, body type, and opportunity — not by intelligence or future capability.', // Day 1
+    'The "no" head shake is a cross-cultural universal — nearly all human cultures use it to signal negation. Your baby has not been explicitly taught it; they have absorbed it from months of observation and now deploy it as a genuine word.', // Day 2
+    'An 11-month growth spurt is common and temporary. It typically involves 2–3 days of increased appetite, more sleep, and possibly more fussiness — then a visible change in height or proportion.', // Day 3
+    'Walking while carrying an object is significantly harder than walking alone. It occupies one or both hands, shifts the centre of gravity, and requires balance adjustments. Your baby practising this is doing serious physical work.', // Day 4
+    'Picture books are not just entertainment at 11 months. Naming images in books and connecting them to real-world objects builds categorical thinking — understanding that "dog" applies to all dogs, not just one particular dog.', // Day 5
+    'The average first-birthday vocabulary is 1–3 words, but the range is 0–10 and all of those can be completely normal. Comprehension matters far more than production at this stage.', // Day 6
+    'Your baby at 11 months can hold a mental image of you when you are out of the room. This object permanence — extended to people — is why they call for you specifically when distressed. You are a consistent, beloved mental model.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-45.js
+++ b/src/data/weeks/week-45.js
@@ -2,13 +2,75 @@
 export const week45 = {
   week: 45,
   ageRange: '11 months old',
-  title: 'Week 45 — 11 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 45 — Climbing, creating, pretending',
+  highlight:
+    'Your baby is starting to climb, starting to scribble, and starting to pretend — three new behaviours that each represent a major leap in how they engage with the physical and social world. They are building toward a self.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.3–9.8 kg / 20.5–21.5 lbs and ~73–76 cm / 29–30 in. Body proportions are shifting — legs are longer, the baby belly is less pronounced, and they are beginning to look like a toddler.',
+    motorSkills:
+      'Walking with more confidence and speed. Stairs are becoming a fascination — babies this age will attempt to climb them at every opportunity (stair gates are not optional). Scribbling with a fat crayon, though grip is still palmar. Balancing on uneven surfaces is improving. Fine motor: stacks 4–5 blocks, turns book pages intentionally.',
+    reflexes:
+      'All movement is voluntary and purposeful. Your baby is becoming a genuine physical adventurer — they will climb on anything that offers a foothold and investigate any height difference with enthusiasm.',
+  },
+  cognitive: {
+    vision:
+      'Your baby scans their environment for opportunities — chairs to climb, objects to reach, spaces to explore. Their visual search is methodical and goal-directed in a way that is unmistakably intentional.',
+    hearing:
+      'Three to five words typical. Follows 2-step instructions, especially when said simply and paired with gesture ("get the ball and bring it here"). Beginning to understand more complex language even when they cannot yet respond in kind.',
+    awareness:
+      'Pretend play is beginning: your baby may feed a doll, talk into a toy phone, or put a stuffed animal to "sleep". This is enormously significant — it means they can represent reality symbolically, using one thing to stand for another.',
+  },
+  sleep: {
+    totalHours: '13–14 hours/day total',
+    nightSleep: '10–12 hours. A consistent bedtime routine is more important than ever — bath, milk, book, bed in the same sequence every night',
+    naps: '2 naps, though the morning nap may be shortening to 30 minutes or less. Some babies are close to the 2-to-1 nap transition but most do better waiting until after the first birthday',
+    notes:
+      'Strong food preferences and refusals are appearing at mealtimes. This is developmentally normal and not a phase you need to correct forcefully — but continuing to offer a variety of foods without pressure prevents neophobia from entrenching.',
+  },
+  feeding: {
+    amount: 'Solid foods provide most nutrition. Breast milk or formula: ~360–480 ml / 12–16 oz per day. At 12 months, the transition to whole cow\'s milk begins — a gentle introduction now helps',
+    frequency: '3 meals, 1–2 snacks, 2–3 milk feeds. Reducing the evening milk feed (if still a large feed) helps build appetite for dinner',
+    hungerCues:
+      'Strong preferences are forming — your baby may reject a food they enjoyed last week. This is normal. Offer it again in two weeks without pressure.',
+    notes:
+      'Preparing for the transition to whole cow\'s milk at 12 months: introduce it gradually, mixed into porridge or offered in a cup in small amounts alongside breast milk or formula. Most babies tolerate the transition easily when it is gradual.',
+  },
+  play: {
+    activities: [
+      'Crayon scribbling: tape paper to a tray or the floor and offer a fat crayon. No instruction needed — the mark-making itself is deeply satisfying and builds pen grip strength for the future',
+      'Dancing: free movement to music of any kind. Babies this age respond to rhythm intuitively and love to dance alongside you',
+      'Pretend play setup: give your baby a doll or stuffed animal and demonstrate feeding it — then hand them the spoon. Follow their lead with how it develops',
+      'Supervised stair climbing: if you have stairs, supervised up-and-down practise (always within arm\'s reach) is safer than prohibition, which just makes stairs more appealing',
+    ],
+    bonding:
+      'Pretend play is your baby\'s first step into symbolic thinking — they are using objects and actions to represent a world beyond what is immediately present. When you play along with their pretending, you validate their interior world and extend their imagination. Getting on the floor and playing along is one of the most developmentally powerful things you can do this month.',
+  },
+  parentTips: {
+    selfCare: [
+      'Stair safety: if you do not have stair gates, get them now. It takes one second for a newly walking baby to reach a staircase. This is not alarmism — it is statistics.',
+      'The whole-milk transition at 12 months is often simpler than parents expect. Start mixing a small amount into food or offering a few sips from a cup this week so it is not a cold-switch at the birthday.',
+      'You are three weeks from the first birthday. If a celebration is happening, keep the guest list to people your baby actually knows and the party length to under 2 hours. Babies this age do not enjoy large gatherings.',
+    ],
+    watchFor: [
+      'Scribbling with a crayon — mark-making is a fine motor and creative milestone',
+      'Pretend play elements: feeding a doll, talking into a toy phone, covering a stuffed animal with a cloth',
+      'Following 2-step simple instructions — shows significant language comprehension',
+    ],
+    callDoctor: [
+      'Climbing without any sense of danger or stopping: while curiosity is normal, complete absence of caution can occasionally signal sensory processing differences worth discussing',
+      'No clear pretend or functional play (using objects as intended) by 11–12 months',
+      'Any regression in communication — fewer sounds, fewer interactions — always worth discussing promptly',
+    ],
+  },
+  dailyFacts: [
+    'Pretend play — feeding a doll, talking on a toy phone — requires your baby to understand that an object can represent something else. This symbolic thinking is the same cognitive capacity that underlies language and, eventually, reading.', // Day 1
+    'Scribbling with a crayon is not random. At 11 months, babies make deliberate marks, look at them, and make more. This back-and-forth between action and observation is a proto-scientific process.', // Day 2
+    'Stair climbing is compelling to babies this age because it is the most challenging vertical surface they can access. The drive to climb is neurological — it develops the vestibular system and spatial awareness.', // Day 3
+    'Dancing to music at 11 months is not just fun. Entraining movement to a beat (even loosely) involves the cerebellum, basal ganglia, and motor cortex all working together — it is a serious neural coordination exercise.', // Day 4
+    'Food refusals at 11–12 months are often related to "neophobia" — a wariness of novel things that is evolutionary. The most effective response is repeated neutral exposure: the food on the plate, no pressure, no drama, week after week.', // Day 5
+    'At 11 months, your baby\'s brain is consuming roughly 60% of total body energy — more than at any other point in life. Every nap, every meal, and every calm moment of play is feeding this extraordinary metabolic demand.', // Day 6
+    'The vocabulary explosion that many parents notice between 18 and 24 months is being set up right now. The words your baby hears, the books you read, the conversations you have — all of it is building the foundation for that later surge.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-46.js
+++ b/src/data/weeks/week-46.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week46 = {
   week: 46,
-  ageRange: '11 months old',
-  title: 'Week 46 — 11 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '11–12 months old',
+  title: 'Week 46 — Almost one',
+  highlight:
+    'Two weeks to the first birthday. Walking is preferred over crawling for most babies now, language comprehension is far ahead of what they can express, and the personality in front of you is unmistakably, irreducibly themselves.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.4–9.9 kg / 20.7–21.8 lbs and ~74–76 cm / 29–30 in. Your baby has roughly tripled their birth weight over the past 11.5 months.',
+    motorSkills:
+      'Walking is the preferred mode of transport for many — crawling is kept as a fast fallback for urgency. Some babies are attempting to run, which mostly looks like fast walking with intermittent crashes. Index-finger pointing is very deliberate, used to direct attention and make requests. Fine motor: handles small objects carefully, places items precisely.',
+    reflexes:
+      'All movements are fully voluntary. Your baby has complete independent control over their body. The last of the primitive reflexes disappeared months ago.',
+  },
+  cognitive: {
+    vision:
+      'Your baby now understands that pictures in books represent real things. They can match a picture of an apple to a real apple when they see both. This representational understanding is a major conceptual achievement.',
+    hearing:
+      'Understands 50+ words despite speaking only 2–6 of them. Responds to their name reliably from across the room. Understands "give it to me", "come here", "no", and simple sentences accompanied by familiar context.',
+    awareness:
+      'Parallel play is beginning — sitting near other children and playing separately but with awareness of them. This is the first stage of social play. Points with the index finger both to request and to share attention ("look at that!"), two distinct and sophisticated social uses of a single gesture.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. Sleep is generally more settled now than the 10-month regression period for most families',
+    naps: '1–2 naps totalling 2–3 hours. Some babies are solidly at 1 nap; most are still on 2. Both are fine at this age',
+    notes:
+      'As the first birthday approaches, some babies experience a brief sleep disruption linked to developmental excitement and awareness. If this happens, maintain routine firmly — this is not the time to introduce new sleep associations.',
+  },
+  feeding: {
+    amount: 'Solid foods are the nutritional foundation. Breast milk or formula: ~360–480 ml / 12–16 oz per day. In 2 weeks, whole cow\'s milk can begin replacing formula',
+    frequency: '3 meals, 1–2 snacks, 2–3 milk feeds. A family-style meal — everyone eating together, same food — is the ideal setup now',
+    hungerCues:
+      'Your baby increasingly indicates what they want by pointing, reaching, or signing. They will often indicate preference between two offered foods. These communications should be taken seriously.',
+    notes:
+      'Cow\'s milk transition at 12 months: offer it in a cup (not a bottle), start with 120 ml / 4 oz per day alongside existing milk feeds, and increase over 2–3 weeks. Most babies adapt easily and quickly.',
+  },
+  play: {
+    activities: [
+      'Parallel play facilitation: a playdate with another baby the same age — let them play near each other with minimal intervention. Social awareness is developing even when interaction looks minimal',
+      'Book sharing with active naming: "where is the dog?" — pause and wait for the point, then confirm enthusiastically. This structured interaction builds vocabulary faster than passive reading',
+      'Outdoor exploration: walking on different surfaces (grass, gravel, sand) develops proprioception and balance adaptation that indoor floors cannot offer',
+      'Simple puzzles: knob puzzles with 2–3 large pieces are within reach for many 11.5-month-olds. The trial, error, and success loop is deeply satisfying',
+    ],
+    bonding:
+      'In two weeks you will have a one-year-old. As the birthday approaches, take a moment to look at what you have built together — not just the baby in front of you, but the relationship between you. The thousands of responses to cries, the night feeds, the songs sung in the dark — all of that created the trust your child carries. You did that.',
+  },
+  parentTips: {
+    selfCare: [
+      'If you are still breastfeeding and planning to continue past 12 months, there is no medical reason to stop — the World Health Organization recommends continuing as long as mutually desired. Ignore anyone who suggests otherwise.',
+      'If you are using formula and cannot wait to be done with the cost and preparation, the 12-month transition to cow\'s milk will feel like a genuine relief. That feeling is valid.',
+      'Do something to mark the first birthday for yourself — not the party, but a private moment: read your first day\'s notes or photos, write something down, acknowledge what this year has been.',
+    ],
+    watchFor: [
+      'Walking preferred over crawling — a walking confidence milestone',
+      'Deliberate index-finger pointing both to request (want that) and declare (look at that) — two distinct social uses',
+      'Parallel play awareness — noticing and responding to other children even when not interacting directly',
+    ],
+    callDoctor: [
+      'No walking or standing at all by 12 months — worth discussing at the 12-month check-up',
+      'No words at all (not even "mama"/"dada" with meaning) by 12 months — mention this explicitly',
+      'Any concerns you have been carrying but have not voiced — the 12-month visit is exactly the time',
+    ],
+  },
+  dailyFacts: [
+    'The index-finger point is one of the most significant gestures in human development. It requires understanding that other people have different visual perspectives and can be directed. Great apes can gesture, but the deliberate declarative point is largely unique to humans.', // Day 1
+    'Parallel play — sitting near other children without interacting — is the first genuine stage of social play. It is not a sign that your baby is unfriendly; it is the developmental entry point to all social interaction that follows.', // Day 2
+    'At almost 12 months, your baby has heard roughly 4–11 million words spoken to them (depending on how much language-rich interaction they have had). This input shapes the language circuits that will drive their later language ability.', // Day 3
+    'Walking on uneven outdoor surfaces is significantly harder and more developmentally valuable than walking on flat floors. Grass, gravel, and sand require constant micro-adjustments from the feet and legs that build proprioception and balance.', // Day 4
+    'The comprehension-to-production gap in language is not unique to babies — it exists in adult second-language learners too. Understanding always precedes speaking because comprehension requires only recognition, while speaking requires recall, planning, and motor execution.', // Day 5
+    'Your baby\'s brain at almost 12 months has developed all the major structural regions it will ever have. What comes next is not the addition of new regions but the vast refinement and myelination of connections — a process that continues into the mid-twenties.', // Day 6
+    'Whole cow\'s milk at 12 months is recommended because it provides the fat, protein, and calories a growing toddler needs. Full-fat (whole) milk is important — lower-fat varieties do not provide adequate caloric density for under-2s.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-47.js
+++ b/src/data/weeks/week-47.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week47 = {
   week: 47,
-  ageRange: '11.5 months old',
-  title: 'Week 47 — 11.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '12 months old',
+  title: 'Week 47 — Almost there',
+  highlight:
+    'A few days from the first birthday. Your baby is walking, talking in their own way, showing pride and humour and love — and they are almost one. The year happened. You did it.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~9.5–10 kg / 21–22 lbs and ~74–77 cm / 29–30.5 in. By the first birthday, most babies have tripled their birth weight and grown ~25 cm / 10 in since birth.',
+    motorSkills:
+      'Walking confidently for most babies, with some attempting to run — clumsy, joyful, and crash-prone. Four to eight teeth typical, with molars possible. Crouches down to pick up objects from the floor. Carries objects in both hands while walking. Turns book pages. Places objects with precision.',
+    reflexes:
+      'Fully voluntary movement. Your baby now plans and executes physical actions with genuine intentionality — reaching for a specific object, navigating around furniture, climbing with calculation.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention is highly selective — your baby fixes on what interests them and ignores what does not. They can follow a fast-moving object across the room and track it when it disappears behind something, then look for it on the other side.',
+    hearing:
+      'Four to eight words is typical, with some babies saying 10 or more and others still at 1–2. All of these are within normal range. Responds to their own name reliably, responds to "no" (though compliance is optional), understands most of what you say in familiar contexts.',
+    awareness:
+      'Shows clear pride in achievements — looks at you after doing something new, grins, sometimes claps for themselves. Shows affection proactively: initiates hugs, gives kisses, pats your face. Sense of humour is evident — does something intentionally funny and watches for your reaction.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. If nights are still rough, the 12-month check-up is a good time to discuss sleep with your doctor',
+    naps: '1–2 naps totalling 2–3 hours. At 12 months, many parents consider the nap transition — but this is highly individual and can happen anywhere from 12 to 18 months',
+    notes:
+      'The 12-month check-up will include discussions about sleep, feeding, development, and vaccinations. It is also a good time to raise anything you have been wondering about but have not asked.',
+  },
+  feeding: {
+    amount: 'Solid foods are the nutritional foundation. Formula or breast milk: ~360–480 ml / 12–16 oz per day. Bottle-to-cup transition should be complete or underway by 12 months',
+    frequency: '3 solid meals plus 1–2 snacks. Milk as a drink with meals or between meals, not as the main meal itself',
+    hungerCues:
+      'Your baby communicates hunger and fullness clearly. Trust their cues — they are very accurate self-regulators when given the chance. Pressure to eat more overrides this self-regulation.',
+    notes:
+      'The 12-month check-up is the time to discuss transitioning from bottle to cup and from formula to whole cow\'s milk, if you have not already. These transitions are manageable with a gradual approach over 2–4 weeks.',
+  },
+  play: {
+    activities: [
+      'Birthday preview: if a party is coming, keep it small and familiar. Your baby does not need a crowd — they need you, a small number of familiar people, and maybe one balloon',
+      'Walking destination games: put something interesting at the end of a hallway and walk toward it together — builds purposeful walking and anticipation',
+      'Stacking competitions: who can stack more blocks? Your baby will love both stacking and knocking over your attempts',
+      'Song requests: sing a song your baby knows and pause at a key word — they may fill in a sound or gesture to complete it, which is early participatory language',
+    ],
+    bonding:
+      'In a few days, your baby turns one. Before that happens, take some time to look at them as they are right now: the way they crawl when they want to be fast, the specific sound of their laugh, the things that make them delighted. This exact version of them only exists for a few more days. You are not mourning — you are witnessing.',
+  },
+  parentTips: {
+    selfCare: [
+      'The 12-month vaccinations include MMR and chickenpox vaccines, which can cause a mild fever or rash 7–12 days later. This is a normal immune response, not illness.',
+      'If the first birthday brings grief alongside celebration — a feeling that the baby phase is over — that is completely valid. The transition to toddlerhood is real, and you are allowed to feel it.',
+      'You have kept a small human alive, safe, and thriving for almost a year. Whatever else is true, that is extraordinary.',
+    ],
+    watchFor: [
+      'Pride in achievement — looking to you after doing something new, smiling, clapping for themselves',
+      'Affection shown proactively: initiating hugs, giving kisses on request or spontaneously',
+      'Humour — doing something they know will make you laugh and watching for your reaction',
+    ],
+    callDoctor: [
+      'Schedule the 12-month well-baby check-up if not already booked — this is a key visit with developmental screening and important vaccines',
+      'Any walking that is consistently one-sided or involves dragging one leg',
+      'Persistent night waking every 1–2 hours at this age — if it is significantly affecting family functioning, this check-up is the right moment to discuss it',
+    ],
+  },
+  dailyFacts: [
+    'By 12 months, the average baby has been held, rocked, fed, and interacted with in roughly 200,000 individual parental interactions. Each one shaped the neural architecture of attachment and trust.', // Day 1
+    'Walking, running, and climbing all originate from the same neural pathway that began with tummy time. Every "pointless" floor time session in the early months was laying the groundwork for what your baby is doing right now.', // Day 2
+    'Self-conscious emotions — pride, embarrassment, shame — begin to emerge around 12 months. When your baby looks to you after an achievement, they are experiencing proto-pride, which requires self-awareness. That awareness is brand new.', // Day 3
+    'The typical 12-month vocabulary of 1–5 words will double or triple in the next 3–6 months for most babies. The "word explosion" at 18 months is not a sudden start — it is the visible result of months of accumulation happening invisibly.', // Day 4
+    'The 12-month check-up includes developmental screening for autism spectrum characteristics. This is routine, not alarming. Early identification of any differences leads to earlier support, which leads to significantly better outcomes.', // Day 5
+    'Bottle use past 12 months is associated with tooth decay, iron-deficiency anaemia (milk overcrowding out iron-rich foods), and speech development delays. The transition to cup is genuinely important, not just a parenting preference.', // Day 6
+    'Your baby has been awake for a cumulative total of roughly 2,500–3,000 hours over the past year. Every one of those waking hours was filled with observation, imitation, practice, play, and relationship — the most intensive learning of any year of their life.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-48.js
+++ b/src/data/weeks/week-48.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week48 = {
   week: 48,
-  ageRange: '11.5 months old',
-  title: 'Week 48 — 11.5 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '12 months old',
+  title: 'Week 48 — One year old',
+  highlight:
+    'Your baby is one year old. From a being who could not lift their own head, who could not see past 30 cm, who slept and fed and slept and fed — to this walking, laughing, pointing, talking, climbing, loving person. You have witnessed the most concentrated burst of human development that will ever occur in a single life. Happy first birthday.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~10 kg / 22 lbs and ~75 cm / 29.5 in at the first birthday — roughly triple birth weight and 25 cm / 10 in taller than the day they arrived. No other year of life will produce growth at this pace.',
+    motorSkills:
+      'Walking independently. Some babies are running clumsily — arms out, grinning, occasionally crashing. Crouches to pick up objects without toppling. Climbs onto low furniture. Stacks 2–4 blocks. Turns book pages. Scribbles. Uses a spoon with messy but genuine intent.',
+    reflexes:
+      'All movement is intentional. The protective, exploratory, and balance reflexes that support walking are mature. Your baby is a fully upright biped, which puts them in a very small group of animals on this planet.',
+  },
+  cognitive: {
+    vision:
+      'Adult-quality vision: 20/20 or close to it, full colour perception, excellent depth perception and tracking. The visual system is complete. What continues to develop is how the brain interprets and acts on what it sees.',
+    hearing:
+      'Two to ten words with meaning. Understanding is far ahead — 50+ words comprehended, simple instructions followed, names of familiar people and objects recognised reliably. The language apparatus is built; the vocabulary will now pour in.',
+    awareness:
+      'Your baby knows who they are. They recognise themselves in mirrors with pleasure. They know their name, know their people, know their home, and know their routines. They have a self. A coherent, distinct, beloved self that did not exist a year ago.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. One-year-olds with a solid bedtime routine generally sleep well — the disruptions of the past year\'s many regressions are mostly behind you',
+    naps: '1–2 naps totalling 2–3 hours. The 2-to-1 nap transition can happen any time from now through 18 months — follow your baby\'s lead',
+    notes:
+      'Sleep at one year can be genuinely good if you have a consistent routine. If it is still hard, you are not alone — roughly 30% of one-year-olds still wake regularly. This is treatable and improvable. The 12-month check-up is the right place to discuss it.',
+  },
+  feeding: {
+    amount: 'Whole cow\'s milk: 350–480 ml / 12–16 oz per day replaces formula. Continue breastfeeding as long as desired by both of you. Solid foods are the primary source of nutrition',
+    frequency: '3 meals plus 1–2 snacks. Milk offered in an open cup or straw cup, not a bottle. Mealtimes ideally happen with the family',
+    hungerCues:
+      'Your one-year-old is an excellent self-regulator of hunger and fullness when given the chance. Trust the cues. A toddler who eats a tiny dinner is very likely to eat a good breakfast.',
+    notes:
+      'The bottle should be retired at 12 months or very soon after. The cup — open, straw, or 360 — is their drinking vessel now. If the bottle is still present at bedtime, it is the single most important habit to change for dental and nutritional health.',
+  },
+  play: {
+    activities: [
+      'Birthday play: a cardboard box, some tissue paper, a single exciting toy. Your baby will enjoy the paper more than most gifts and the attention more than any of it',
+      'Walk in a new place: a new park, a new neighbourhood, anywhere with different sights and surfaces — at one year, the world is a playground of unmapped wonders',
+      'Music and dancing: put on music you love and dance together. Your joy is contagious and your baby has been watching you respond to music for a year',
+      'Water play: a shallow bowl of water and some cups and spoons — pouring, splashing, and exploring water properties is endlessly absorbing and purely joyful',
+    ],
+    bonding:
+      'Happy first birthday to you both. You did not just keep a baby alive this year — you built a relationship. You learned each other. You created safety, you created routine, you created joy. The person in front of you is who they are in part because of the thousands of moments you chose to show up. That is love made visible, and it is extraordinary.',
+  },
+  parentTips: {
+    selfCare: [
+      'On the actual birthday, give yourself permission to feel whatever you feel — pride, relief, grief, overwhelming love, or a quiet exhausted peace. All of it is the right answer.',
+      'If you have a partner, take a moment today to acknowledge what you have been through together. A year of new parenthood tests a relationship in ways nothing else does. You are still here. That matters.',
+      'If you are a single parent: what you have done this year, without a partner beside you, is remarkable. You are the proof that it can be done, and done beautifully.',
+    ],
+    watchFor: [
+      'Walking independently — the defining gross motor milestone of the first year',
+      'Two or more words with clear meaning — the foundation of language is laid',
+      'Self-recognition in mirrors — a marker of emerging self-awareness',
+    ],
+    callDoctor: [
+      'Not walking or even attempting to stand independently by 12 months — worth discussing at the check-up',
+      'No words with meaning at all by 12 months — mention this at the 12-month visit',
+      'Any developmental regression — loss of skills previously present — always warrants prompt follow-up',
+    ],
+  },
+  dailyFacts: [
+    'A newborn human is more helpless at birth than almost any other mammal. A foal stands within an hour; a human baby takes roughly 12 months. That gap is the price of our large brain — born early so the skull can fit through the birth canal.', // Day 1
+    'Over the past 365 days, your baby\'s brain has formed approximately 700 new neural connections per second. No other period of brain development — not adolescence, not adulthood — comes close to this rate.', // Day 2
+    'The first year of life is the foundation for every attachment relationship your child will form for the rest of their life. Secure attachment built in the first year is a protective factor that research shows lasts across the entire lifespan.', // Day 3
+    'Your baby\'s first birthday is also yours as a parent. You have never done this before. You figured it out in real time, on no sleep, with everything you had. That is not small — that is one of the hardest things humans do.', // Day 4
+    'The average one-year-old takes 2,000–3,000 steps per day. Each step is a micro-experiment in balance, weight transfer, and spatial navigation. Walking will become unconscious very soon — but right now, it is still a magnificent achievement every single time.', // Day 5
+    'Language at 12 months: 2–10 spoken words, but understanding of 50–100. Within the next 6 months, the spoken vocabulary will typically expand to 50+ words. The gap closes dramatically in the second year.', // Day 6
+    'You have read to your baby, sung to your baby, talked to your baby through every mundane task for a year. Research is unambiguous: this is the single most powerful thing a parent can do for language development. You have been doing it all along.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-49.js
+++ b/src/data/weeks/week-49.js
@@ -2,13 +2,75 @@
 export const week49 = {
   week: 49,
   ageRange: '12 months old',
-  title: 'Week 49 — 12 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 49 — Life after the birthday',
+  highlight:
+    'The birthday is behind you, but the development keeps accelerating. Your one-year-old is still figuring out walking, falling constantly, and starting to use language in ways that will surprise you almost daily now.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~10 kg / 22 lbs and ~75 cm / 29.5 in. Growth rate slows to roughly 1 cm / 0.5 in per month and 85–140 g / 3–5 oz per week from here through the second year.',
+    motorSkills:
+      'Walking and falling a lot — this is completely normal. Falls are part of the calibration process, not a sign of a problem. Running attempts are common — fast lurching with arms out and frequent crashes. Stacks 3–4 blocks with concentration. Scribbles independently. Climbs stairs if gates allow (supervised only).',
+    reflexes:
+      'Protective fall responses are well established. Most falls result in a surprised look rather than injury. Your baby is learning to judge distances and surfaces — a process that will take another year to fully refine.',
+  },
+  cognitive: {
+    vision:
+      'Your baby points at pictures in books and looks to you to confirm the name. This "check-in" behaviour — pointing, then looking at you, then back at the picture — is active vocabulary acquisition in real time.',
+    hearing:
+      'Vocabulary is growing rapidly — words are being added weekly now. A typical one-year-old just past their birthday says 2–10 words, but this number can double within the next few weeks for some babies. Understanding remains far ahead of speaking.',
+    awareness:
+      'Separation anxiety may spike again just after the first birthday. The transition to toddlerhood brings new awareness, and new awareness can bring new worries. Consistent routines and confident goodbyes are the most effective response.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. If the birthday week was disrupted by events and visitors, re-establishing the normal routine promptly helps everyone settle',
+    naps: '1–2 naps. If transitioning from 2 to 1 nap, do it gradually: extend morning awake window by 15 minutes every few days until one midday nap is sustainable',
+    notes:
+      'The 2-to-1 nap transition can happen anywhere from 12 to 18 months. Rushing it causes overtiredness and harder nights. Signs it is time: consistently fighting one nap, taking 45+ minutes to fall asleep for one nap, or napping so late it disrupts bedtime.',
+  },
+  feeding: {
+    amount: 'Whole cow\'s milk: 350–480 ml / 12–16 oz per day. Solid foods across all food groups. Appetite may fluctuate more than it did at 11 months — this is normal toddler eating',
+    frequency: '3 meals, 1–2 snacks. Milk in a cup, not a bottle. Water freely. Juice is not recommended for children under 2',
+    hungerCues:
+      'Toddlers are famously variable eaters. A good week followed by a week of apparent food refusal is normal. The division of responsibility in feeding: you decide what to offer and when; your baby decides whether and how much.',
+    notes:
+      'Transitioning from bottle to cup: if the bottle is still present, remove it now. The longest you want to extend this is to 15 months. The older a toddler gets, the more attached to the bottle they become and the harder the transition. Now is easier than later.',
+  },
+  play: {
+    activities: [
+      'Push-toy walking: a sturdy push toy (shopping cart, walker) builds walking confidence and balance — not necessary for walking, but joyful and useful',
+      'Sorting by colour or size: offer two buckets and objects of two colours and demonstrate putting like with like. Most babies this age cannot do it reliably, but the attempt is the point',
+      'Bubbles: blowing bubbles for your baby to chase and pop is one of the finest activities at this age — movement, tracking, joy, and cause-and-effect all at once',
+      'Shape sorter revisited: at 12 months, many babies can get at least one shape in reliably with perseverance. The persistence when it does not work immediately is itself a developmental milestone',
+    ],
+    bonding:
+      'Falling is part of learning to walk, and how you respond to falls shapes your baby\'s relationship with challenge and frustration. A calm, matter-of-fact response ("oops! up you get") teaches resilience. An anxious, rushing-to-comfort response teaches that falls are catastrophic. You do not need to be stone-faced — warmth and calm together are exactly right.',
+  },
+  parentTips: {
+    selfCare: [
+      'The 12-month vaccines (if received at the birthday check-up) may cause a rash or mild fever 7–12 days after the MMR. This is the immune system responding correctly — not illness, not a reaction to be worried about.',
+      'If the bottle is not yet gone, the next two weeks are the window. Beyond 15 months, the habit becomes significantly harder to break. Your future self will be grateful you did it now.',
+      'Post-birthday parenting can feel oddly flat after a year of intense firsts. This is normal. The second year has its own extraordinary milestones — they are just a little less frantic.',
+    ],
+    watchFor: [
+      'New words appearing week-by-week — even one new clear word per week is good language progress',
+      'Pointing at pictures in books and looking to you for the word — active vocabulary acquisition',
+      'Stacking 3–4 blocks — fine motor and spatial reasoning milestone',
+    ],
+    callDoctor: [
+      'If the 12-month check-up has not happened yet, schedule it now — it includes important developmental screening and vaccines',
+      'Persistent limping or asymmetric walking once walking is established',
+      'Significant separation anxiety that prevents settling even after 20–30 minutes and is worsening rather than improving over weeks',
+    ],
+  },
+  dailyFacts: [
+    'Falls while learning to walk are developmentally necessary. Each fall provides sensory feedback that refines balance and motor planning. Babies who are protected from all falls actually take longer to become proficient walkers.', // Day 1
+    'The word explosion — a sudden rapid increase in vocabulary — typically happens between 18 and 24 months but is set up by the slow accumulation happening right now. Every word your baby hears this month is being stored.', // Day 2
+    'Separation anxiety peaks at around 12–18 months. It is linked to the development of object permanence — your baby now knows you exist when you are gone, and that knowledge is, briefly, distressing. It is a sign of cognitive advancement.', // Day 3
+    'The 2-to-1 nap transition is one of the most talked-about transitions in toddlerhood. Most children make it between 14 and 18 months, but the range is 12–21 months. There is no rush — two naps as long as they work is always better than one that does not.', // Day 4
+    'Whole cow\'s milk provides the fat your baby\'s brain needs — 60% of the brain is fat, and it continues to be built and myelinated throughout childhood. Full-fat dairy is not a luxury for under-2s; it is a developmental requirement.', // Day 5
+    'At 12 months, your baby can follow a 2-step instruction if the steps are familiar and the context is clear ("get your shoes and bring them here"). This requires holding two pieces of information in working memory simultaneously.', // Day 6
+    'Pushing and pulling objects while walking — a push toy, a laundry basket, a chair — is not just fun. It provides resistance that builds lower body strength and balance, and it gives the hands something to do which paradoxically often improves walking stability.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-50.js
+++ b/src/data/weeks/week-50.js
@@ -2,13 +2,75 @@
 export const week50 = {
   week: 50,
   ageRange: '12 months old',
-  title: 'Week 50 — 12 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  title: 'Week 50 — Walking gets easier',
+  highlight:
+    'Watch the arms come down. In the early weeks of walking, arms are raised for balance — this week you may notice them lowering, the gait becoming more fluid, the confidence unmistakable. Your baby is becoming a walker, not just someone who can walk.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~10 kg / 22 lbs and ~75–76 cm / 29.5–30 in. Growth is steady, slow, and healthy — the dramatic pace of the first six months is well behind you.',
+    motorSkills:
+      'Walking with arms less raised than a few weeks ago — a sign of improving balance. Bending down to pick up objects without toppling is more reliable. First attempts at climbing stairs holding a rail or the wall (always supervised). Can kick a ball with reasonable aim. Stacks 4–5 blocks. Scribbles with increasing control.',
+    reflexes:
+      'Balance and protective reactions are mature. Your baby\'s body has developed the automatic responses needed to keep them upright in most situations. What remains is experience — learning the specifics of their environment.',
+  },
+  cognitive: {
+    vision:
+      'Points at pictures in books, makes a sound or says the name, looks to you for confirmation. This checking-in behaviour is how your baby is building vocabulary: they point, you name, they store. It is systematic and efficient.',
+    hearing:
+      'Four to ten words is typical, with rapid addition of new words. Your baby can now "read" your emotional state from your voice alone — they know from tone whether you are pleased, anxious, or stern before the words register.',
+    awareness:
+      'Pretend play is expanding — feeding multiple dolls, putting them to sleep, offering the spoon to you. Using a spoon to self-feed is genuine even if messy, and the mess is the price of the skill. Strong preferences for routine: disruptions to the expected sequence of the day cause real distress.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. Sleep is generally more predictable now than at any point in the first year for most families',
+    naps: '1–2 naps. If still on 2 naps, both are probably in the 30–90 minute range. The midday nap may be extending as the morning nap shortens',
+    notes:
+      'Routine is a powerful sleep tool at this age. Your baby\'s circadian rhythm is well established, and predictable sleep and wake times reinforce it. Even on weekends, maintaining timing within 30 minutes of normal makes a noticeable difference.',
+  },
+  feeding: {
+    amount: 'Whole cow\'s milk: ~350–480 ml / 12–16 oz per day. Solid foods across all food groups at every meal. Iron-rich foods (meat, lentils, fortified cereals) are especially important as breast milk and formula decline',
+    frequency: '3 meals, 1–2 snacks. Self-feeding with fingers and beginning to use a spoon. Offer a spoon alongside finger foods every meal',
+    hungerCues:
+      'Your baby can now tell you what they want with words, points, and gestures. "More" (signed or spoken), pointing at specific foods, and bringing you their bowl are all clear requests. Honour them.',
+    notes:
+      'Iron deficiency is the most common nutritional deficiency in toddlers and is largely preventable. Keep red meat, lentils, beans, and iron-fortified foods in regular rotation, and offer vitamin C alongside them to improve absorption.',
+  },
+  play: {
+    activities: [
+      'Spoon practice every meal: offer a loaded preloaded spoon and let your baby guide it to their mouth — success is partial and the floor suffers, but the skill develops only through practice',
+      'Book pointing sessions: "show me the cat" and wait for the point — then name it, describe it, make the sound. This structured book-sharing is vocabulary building at its most efficient',
+      'Ball kicking: a large soft ball on the floor invites kicking with both feet — balance, coordination, and cause-and-effect all in one',
+      'Simple matching: two pairs of identical objects — can your baby put the matching ones together? At 12 months this is aspirational, but the attempt builds categorisation skills',
+    ],
+    bonding:
+      'Your baby\'s love of routine extends to how they play with you. They may request the same book repeatedly, the same song, the same game. This is not boredom — it is mastery seeking. Each repetition builds fluency and confidence. Being the reliable, predictable partner in these repeated games is one of the most meaningful things you can offer right now.',
+  },
+  parentTips: {
+    selfCare: [
+      'Iron-deficiency anaemia is also common in parents — particularly mothers — after a year of pregnancy, birth, and postpartum demands. If you are exhausted beyond what sleep explains, ask your doctor to check your iron.',
+      'Your toddler\'s growing autonomy will sometimes feel like defiance. It is not — it is healthy individuation. The "no" and the strong preferences are their self emerging. You can hold limits while validating the feeling.',
+      'Week 50: you are two weeks from having completed the whole first year as a parent. That is real. It counts.',
+    ],
+    watchFor: [
+      'Arms lowering while walking — a clear sign of improving balance',
+      'Spoon use with real intent, even if messy',
+      'Pointing at and naming pictures in books (or attempting the name)',
+    ],
+    callDoctor: [
+      'Continued asymmetric walking or limping after two or more weeks of established walking',
+      'No new words in the past month, or a loss of words that were previously present',
+      'Signs of iron deficiency: unusual pallor, extreme fatigue, or appetite for non-food items (pica)',
+    ],
+  },
+  dailyFacts: [
+    'The typical walking gait at 12 months has arms raised and feet wide — by 18 months, arms have lowered and the stance has narrowed. This transition takes months of unconscious refinement and thousands of steps.', // Day 1
+    'Self-feeding with a spoon is a 12–18 month skill in development. The mess is the point — the motor feedback of scooping, carrying, and depositing builds proprioception and fine motor control that neat adult-fed meals cannot replicate.', // Day 2
+    'Your baby\'s preference for routine is not rigidity — it is intelligence. Predicting what comes next reduces cognitive load and frees up mental resources for learning new things. Routine is supportive, not limiting.', // Day 3
+    'Pretend play at 12 months is "object-based" — the doll gets fed because that is what you do with dolls. At 18 months, pretend play becomes substitutive — a banana becomes a telephone. This is a major jump in symbolic thinking.', // Day 4
+    'Iron-rich foods are especially critical in the second year because breast milk and formula (which were providing iron) are being replaced by cow\'s milk, which contains minimal iron. Meat, lentils, beans, and fortified cereals fill the gap.', // Day 5
+    'Toddlers at 12–13 months show a striking tendency to categorise objects. They are not just learning individual words — they are learning categories: "all dogs are dogs, even ones they have never seen." This generalisation is a sophisticated cognitive feat.', // Day 6
+    'Your baby at 12 months can solve "detour problems" — they know that the shortest path to something is not always the direct one, and they will navigate around obstacles to reach a goal. This spatial planning is uniquely human.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-51.js
+++ b/src/data/weeks/week-51.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week51 = {
   week: 51,
-  ageRange: '12 months old',
-  title: 'Week 51 — 12 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '12–13 months old',
+  title: 'Week 51 — Into the second year',
+  highlight:
+    'You are in the second year now, and the developmental landscape is changing. Walking is becoming the background, not the headline. Language is moving to the foreground. The baby is becoming a toddler — curious, determined, funny, and entirely themselves.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~10–10.2 kg / 22–22.5 lbs and ~75–77 cm / 29.5–30.5 in. Physical growth continues at a steady, slow pace compared to the first six months.',
+    motorSkills:
+      'Walking and cruising confidently. Running attempts are more sustained and less crash-prone than two weeks ago. Bending to pick up objects is fluid. Carrying objects while walking is established. Using spoon and fork with real intent and improving accuracy. Fine motor: precise handling of small objects, putting pieces into simple puzzles.',
+    reflexes:
+      'Fully voluntary movement throughout. Your toddler is a mobile, exploring, consequence-free investigator of every corner of your home — which is exactly how it should be, and exactly why baby-proofing remains critical.',
+  },
+  cognitive: {
+    vision:
+      'Visual attention to fine detail is strong — your toddler notices the small insect on the ground, the button that is slightly loose, the thing you thought they could not see from there. Nothing escapes them.',
+    hearing:
+      'Saying the name of familiar people — "mama", "dada", a version of a sibling or pet name. Understanding is exceptional: simple sentences, names of many objects and people, emotional tone of voice. Waves to greet people proactively, not just on cue.',
+    awareness:
+      'Plays pretend actively: feeding dolls and stuffed animals, making them sleep, covering them with cloth. Uses "tools" — a stick to reach something, a stool to climb for something out of reach. This problem-solving with objects is a significant cognitive milestone.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours. Most one-year-olds sleep through the night reliably at this point, though individual variation is wide',
+    naps: '2 naps is still completely normal and appropriate. 1 nap is beginning for some babies. Do not rush the transition — 2 naps until 14–18 months is common and healthy',
+    notes:
+      'If your baby is on 2 naps and both are solid, do not fix what is not broken. The move to 1 nap will announce itself clearly when it is time — fights at one nap that do not improve over a week or two, or a nap so late it pushes bedtime uncomfortably.',
+  },
+  feeding: {
+    amount: 'Whole cow\'s milk: ~350–480 ml / 12–16 oz per day. Three solid meals plus 1–2 snacks. All food groups present, textures expanding toward normal family food',
+    frequency: 'Family mealtimes are the ideal structure now — same food, same time, shared table. This normalises eating and dramatically reduces toddler food battles later',
+    hungerCues:
+      'Your toddler communicates hunger and fullness very clearly. Trust the signals. A child who eats well at one meal and very little at the next is self-regulating across meals, not starving.',
+    notes:
+      'By 13 months, if the bottle is still present, the transition needs to happen now. The older a toddler becomes before dropping the bottle, the harder it is. A few difficult days now is significantly easier than the struggle at 18 months.',
+  },
+  play: {
+    activities: [
+      'Tool use challenges: put a toy just out of reach with a string attached — does your baby pull the string? This is problem-solving with tools and it is impressive when it appears',
+      'Pretend play expansion: set up a small "kitchen" with pots, spoons, and play food. Follow your baby\'s lead and play alongside them without directing',
+      'Water pouring: bath time or a bowl of water with cups — pouring, transferring, filling and emptying teaches volume, cause-and-effect, and provides deep sensory satisfaction',
+      'Simple music instruments: a drum, shakers, or banging pots — making music, stopping, making it again is rhythm and cause-and-effect combined with the joy of sound',
+    ],
+    bonding:
+      'One milestone check for the one-year mark: is your baby walking? Yes — on their own timeline, whether last week or three months ago. Are they using words? Yes — even one or two is the start of language. Do they smile socially? Yes — the social smile has been here for months. If all three are present, you are looking at a developing, connected, thriving child. That is because of you.',
+  },
+  parentTips: {
+    selfCare: [
+      'You are now officially out of the first year. The second year has its own challenges — toddler autonomy, language frustration, boundary-testing — but it also has full sentences, genuine humour, and a child who can tell you what they need. It gets more interesting.',
+      'If postpartum depression or anxiety symptoms are still present at 12–13 months, please mention this to your doctor. Treatment is available and effective at any stage, not just the immediate postpartum period.',
+      'Look at a photo of your baby from week 1 and a photo of them now. Hold both in your mind. That is time. That is what you have been living.',
+    ],
+    watchFor: [
+      'Using tools to solve problems (string to pull a toy, stool to climb) — a notable cognitive milestone',
+      'Waves to greet people proactively and spontaneously',
+      'Pretend play with dolls or animals — feeding, sleeping, covering — symbolic play is active',
+    ],
+    callDoctor: [
+      'Not walking at all by 15 months — this is the window where paediatric assessment becomes important',
+      'Fewer than 2 words with meaning by 15 months, or any loss of words — always worth prompt follow-up',
+      'Concerns about hearing that have been on your mind — act on them now; early assessment is always better',
+    ],
+  },
+  dailyFacts: [
+    'Tool use — using one object to obtain or affect another — is a cognitive milestone that separates humans from most other animals. When your toddler uses a stick to reach a toy or pulls a tablecloth to get something on top of it, they are demonstrating this capacity.', // Day 1
+    'The second year of life will bring the "vocabulary explosion" — a period of rapid word acquisition often starting around 18 months. The slow accumulation happening right now is what makes that explosion possible.', // Day 2
+    'Toddlers at 12–13 months are entering a phase of growing autonomy that will peak around 2 years. The foundation you build now — clear, warm limits with genuine responsiveness — shapes how easily they navigate that phase.', // Day 3
+    'Two naps remain entirely appropriate and healthy up to 14–18 months for many children. The pressure to drop to one nap early is social, not developmental. If two naps are working, they are working.', // Day 4
+    'Pretend play at this age is primarily imitative — copying real-world actions in a play context. It will evolve into substitutive play (one object stands for another) by around 18 months, and then into narrative play (a sequence of events tells a story) by 2–3 years.', // Day 5
+    'The social smile — which first appeared around 6–8 weeks — has evolved into a full social communication tool. Your toddler now uses it to greet, to charm, to share joy, and to check your reaction. It is no longer a reflex; it is a social act.', // Day 6
+    'At 12–13 months, your baby has heard thousands of hours of language. The neural pathways for their native language are deeply established. Any language they hear regularly now — a second language spoken at home, for example — has an extraordinarily good chance of being acquired with native-speaker fluency.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/data/weeks/week-52.js
+++ b/src/data/weeks/week-52.js
@@ -1,14 +1,76 @@
 /** @type {import('../schema.js').WeekEntry} */
 export const week52 = {
   week: 52,
-  ageRange: '12 months old',
-  title: 'Week 52 — 12 months old',
-  highlight: 'Content coming soon.',
-  physical: { size: '', motorSkills: '', reflexes: '' },
-  cognitive: { vision: '', hearing: '', awareness: '' },
-  sleep: { totalHours: '', nightSleep: '', naps: '', notes: '' },
-  feeding: { amount: '', frequency: '', hungerCues: '', notes: '' },
-  play: { activities: [], bonding: '' },
-  parentTips: { selfCare: [], watchFor: [], callDoctor: [] },
-  isStub: true,
+  ageRange: '13 months old',
+  title: 'Week 52 — One complete revolution',
+  highlight:
+    'This is the end of the first year of your baby\'s life — and the end of this journey with them. What you have witnessed is the most remarkable developmental story in all of nature: a helpless newborn becoming a walking, talking, laughing, loving person in exactly 52 weeks. That happened. You were there for all of it.',
+  illustration: '/illustrations/baby-16.png',
+  physical: {
+    size: 'Average ~10.2 kg / 22.5 lbs and ~76–78 cm / 30–30.5 in. In the year ahead, your toddler will grow more slowly — roughly 10–12 cm / 4–5 in — but the changes in capability will be extraordinary.',
+    motorSkills:
+      'Walking is established and becoming automatic. Small objects handled with care and precision — a pincer grip that would have been impossible six months ago is now routine. Simple pretend play involves physical sequencing. Running, climbing, and stair attempts continue to improve with daily practice.',
+    reflexes:
+      'All movement is fully voluntary and purposeful. The next phase of motor development is refinement — precision, speed, coordination, and the gradual ability to combine physical actions with cognitive tasks.',
+  },
+  cognitive: {
+    vision:
+      'Visual processing is complete in the functional sense. Your toddler\'s eyes and visual cortex are doing everything they will ever do — the development from here is in interpretation, attention, and the connection between seeing and understanding.',
+    hearing:
+      'Language is accelerating week by week. Vocabulary is building toward the explosion at around 18 months. Your toddler understands simple sentences, names of people and objects, emotional tone, and intent. They are decoding language with impressive accuracy.',
+    awareness:
+      'Personality is unmistakable and irreducible — the specific blend of temperament, preferences, humour, and social style that belongs only to your child is clearly present. This is who they are. You have had the privilege of being present for its emergence.',
+  },
+  sleep: {
+    totalHours: '12–14 hours/day total',
+    nightSleep: '10–12 hours',
+    naps: '1–2 naps. Whatever is working consistently for your family is the right answer — there is no single schedule that every 13-month-old must follow',
+    notes:
+      'Going forward, sleep will remain generally stable until new developmental surges bring temporary disruptions. The most common ones: the 18-month regression (language and autonomy), the 2-year regression (awareness and imagination), and the dropping of the last nap around 3 years.',
+  },
+  feeding: {
+    amount: 'Whole cow\'s milk: ~350–480 ml / 12–16 oz per day. Three solid meals plus snacks. Most family foods are now accessible with appropriate preparation',
+    frequency: '3 meals and 1–2 snacks. If the bottle is still present, now is the last comfortable window to remove it without significant resistance',
+    hungerCues:
+      'Your toddler\'s appetite is governed by growth rate, activity level, and individual variation. The division of responsibility holds: you offer, they choose. This approach, maintained consistently, produces the most resilient eaters.',
+    notes:
+      'The eating adventure of toddlerhood is just beginning — food refusals, extreme preferences, and the famous "white food only" phase are all ahead for many families. Repeated neutral exposure and family meals are the two evidence-based tools that help most.',
+  },
+  play: {
+    activities: [
+      'Free outdoor time every day: unstructured time in a yard or park — exploring, moving, looking at things — is developmentally irreplaceable and deeply regulating for toddlers',
+      'Books with more complexity: books with simple storylines, not just naming books — your toddler can now begin to follow a basic narrative sequence',
+      'Building and destroying: blocks, stacking cups, anything that can be assembled and knocked down — the cycle of creation and destruction is a core toddler cognitive activity',
+      'Singing together: songs with actions, songs with repetitive lines, any song both of you know — shared music is one of the oldest and most effective forms of human bonding',
+    ],
+    bonding:
+      'You have guided a human being through their first complete revolution around the sun. That is the most irreplaceable role one person can play in another\'s life. Whatever comes next — the toddler years, the school years, the turbulent teenage years — it all grows from the root you have been building for 52 weeks. The relationship you have built is the foundation everything else stands on. Take care of it. Take care of yourself. And keep going.',
+  },
+  parentTips: {
+    selfCare: [
+      'At 13 months, many parents are only beginning to process what the past year was. If you have not had space to reflect on it — the difficulty, the growth, the love — make some. It matters to integrate this year, not just survive it.',
+      'Your identity has changed in the past year. You are still all the things you were before, and now you are also a parent. Integrating these identities takes time and is ongoing — be patient with the process.',
+      'If there are things about the first year you wish had been different — in your parenting, in your circumstances, in yourself — hold them with honesty and self-compassion. Learning continues. The second year gives you more chances.',
+    ],
+    watchFor: [
+      'Vocabulary continuing to grow — at least a few new words per month leading toward the 18-month explosion',
+      'Walking becoming automatic — less focused effort, more fluent movement, arms lowering',
+      'Pretend play growing in complexity — longer sequences, more varied props, beginning to involve you',
+    ],
+    callDoctor: [
+      'No walking by 15 months — paediatric assessment is important at this point',
+      'Fewer than 2 words with meaning by 15 months, or any regression in words or social engagement',
+      'Any concern that has been on your mind — the 15-month check-up is coming, but do not wait if something feels wrong. You know your child. Your instincts count.',
+    ],
+  },
+  dailyFacts: [
+    'In 52 weeks, your baby\'s brain has grown from roughly 25% of adult size to about 70% of adult size. No other organ in the body undergoes change at this scale in this timeframe.', // Day 1
+    'The first year\'s most important developmental achievement is not walking or talking — it is attachment. Secure attachment, built through thousands of responsive interactions, is the foundation for emotional regulation, social competence, and resilience across the entire lifespan.', // Day 2
+    'Your toddler at 13 months has a sense of humour. They know what is funny, they set up situations to be funny, and they watch your face to confirm the comedic success. Shared laughter is one of the deepest forms of social bonding across all human cultures.', // Day 3
+    'The vocabulary explosion at 18 months — when many children suddenly add multiple words per day — is made possible by "fast mapping": the brain\'s ability to connect a new word to a concept after just one or two exposures. This capacity is emerging right now.', // Day 4
+    'Toddlerhood, which you are entering, is characterised by the tension between attachment (stay close, I need you) and exploration (go away, I do it myself). Your child will toggle between these states many times per day. Both states are healthy; both need your response.', // Day 5
+    'The first word is a milestone. The 50th word, which comes between 16 and 24 months for most children, is when the word explosion begins and language becomes self-accelerating. You are heading toward that now.', // Day 6
+    'You have been there for week 1 through week 52. You have read these entries, noticed these milestones, worried the right worries, and celebrated the right moments. That attentiveness — that showing up — is exactly what your child needed. Well done.', // Day 7
+  ],
+  isStub: false,
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -927,6 +927,33 @@ body {
   text-decoration: line-through;
 }
 
+/* Daily fact card */
+.home-daily-fact {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  box-shadow: 0 2px 12px rgba(58, 42, 74, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  border-left: 3px solid var(--color-primary);
+}
+
+.home-daily-fact-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  opacity: 0.9;
+}
+
+.home-daily-fact-text {
+  font-size: 0.9rem;
+  color: var(--color-text);
+  line-height: 1.65;
+}
+
 /* AI upsell banner */
 .home-ai-banner {
   background: linear-gradient(135deg, var(--color-lavender), var(--color-blue));
@@ -1125,6 +1152,38 @@ body {
   left: 0;
   color: var(--color-primary);
   font-weight: 700;
+}
+
+/* Daily insights list in WeekContent */
+.week-daily-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  counter-reset: none;
+}
+
+.week-daily-item {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr;
+  gap: var(--space-sm);
+  align-items: baseline;
+}
+
+.week-daily-day {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  white-space: nowrap;
+}
+
+.week-daily-text {
+  font-size: 0.875rem;
+  color: var(--color-text);
+  opacity: 0.85;
+  line-height: 1.6;
 }
 
 /* ─── Milestones screen ───────────────────────────────────── */

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -47,14 +47,16 @@ describe('App — profile saved', () => {
   it('shows week content for a full-content week', () => {
     saveProfile(7) // 7 weeks ago → week 8 (full content)
     render(<App />)
-    expect(screen.getByText(/social smiles/i)).toBeInTheDocument()
+    // All weeks now have full content — check the highlight text is rendered
+    expect(screen.getAllByText(/social smiles/i).length).toBeGreaterThan(0)
   })
 
-  it('shows no full-week content for a stub week', () => {
-    saveProfile(1) // 1 week ago → week 2 (stub)
+  it('shows full content for all weeks including previously-stub weeks', () => {
+    saveProfile(1) // 1 week ago → week 2 (now full content)
     render(<App />)
-    expect(screen.queryByText(/social smiles/i)).not.toBeInTheDocument()
     expect(screen.getByText('Week 2')).toBeInTheDocument()
+    // Week card highlight is shown (not the "coming soon" stub message)
+    expect(screen.queryByText(/content coming soon/i)).not.toBeInTheDocument()
   })
 
   it('clears profile when "Change birthday" is clicked', () => {

--- a/src/test/data/index.test.js
+++ b/src/test/data/index.test.js
@@ -55,8 +55,8 @@ describe('getAllWeeks()', () => {
 })
 
 describe('getFullWeeks()', () => {
-  it('returns exactly 13 full weeks (4–16)', () => {
-    expect(getFullWeeks()).toHaveLength(13)
+  it('returns all 52 weeks (all weeks now have full content)', () => {
+    expect(getFullWeeks()).toHaveLength(52)
   })
 
   it('only contains weeks with isStub: false', () => {
@@ -65,13 +65,11 @@ describe('getFullWeeks()', () => {
     })
   })
 
-  it('contains exactly weeks 4 through 16', () => {
+  it('contains all weeks 1 through 52', () => {
     const weekNumbers = getFullWeeks().map(w => w.week)
-    for (let w = 4; w <= 16; w++) {
+    for (let w = 1; w <= 52; w++) {
       expect(weekNumbers).toContain(w)
     }
-    expect(weekNumbers).not.toContain(3)
-    expect(weekNumbers).not.toContain(17)
   })
 
   it('is sorted by week number ascending', () => {
@@ -149,7 +147,7 @@ describe('WeekEntry schema conformance', () => {
     })
   })
 
-  it('full weeks (4–16) have non-empty content in all sections', () => {
+  it('all weeks have non-empty content in all sections', () => {
     getFullWeeks().forEach(w => {
       expect(w.highlight, `week ${w.week} highlight`).not.toBe('')
       expect(w.physical.motorSkills, `week ${w.week} motorSkills`).not.toBe('')
@@ -160,10 +158,20 @@ describe('WeekEntry schema conformance', () => {
     })
   })
 
-  it('stub weeks have isStub: true', () => {
+  it('no stub weeks remain', () => {
     const stubs = getAllWeeks().filter(w => w.isStub)
-    // weeks 1–3 and 17–52 = 3 + 36 = 39 stubs
-    expect(stubs).toHaveLength(39)
+    expect(stubs).toHaveLength(0)
+  })
+
+  it('every week has dailyFacts with exactly 7 entries', () => {
+    getAllWeeks().forEach(w => {
+      expect(Array.isArray(w.dailyFacts), `week ${w.week} dailyFacts is array`).toBe(true)
+      expect(w.dailyFacts, `week ${w.week} dailyFacts length`).toHaveLength(7)
+      w.dailyFacts.forEach((fact, i) => {
+        expect(typeof fact, `week ${w.week} day ${i + 1} fact is string`).toBe('string')
+        expect(fact.length, `week ${w.week} day ${i + 1} fact is non-empty`).toBeGreaterThan(0)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- **Fill 39 stub weeks**: Weeks 1–3 (newborn) and 17–52 (4–13 months) now have complete content — physical development, cognitive/sensory, sleep, feeding, play activities, and parent tips
- **Add `dailyFacts` to all 52 weeks**: 7 unique facts/tips per week (one per day), surfaced on the home screen so parents see a fresh update every day of the first year
- **New UI**: Home screen now shows a "Today" card with that day's specific fact; Week detail view shows a "Daily insights" section with all 7 day-labelled facts
- **Tests updated**: All 61 tests pass; added a new `dailyFacts` schema conformance test

## What changed

| Area | Change |
|---|---|
| `src/data/weeks/week-01..03.js` | Full newborn content replacing stubs |
| `src/data/weeks/week-17..52.js` | Full 4–13 month content replacing stubs |
| `src/data/weeks/week-04..16.js` | `dailyFacts` added to existing full weeks |
| `src/data/schema.js` | `dailyFacts: string[]` field documented |
| `src/data/index.js` | `getCurrentDayOfWeek(birthday)` utility added |
| `src/components/HomeScreen.jsx` | "Today" daily fact card |
| `src/components/WeekContent.jsx` | "Daily insights" Day 1–7 section |
| `src/styles/main.css` | Styles for new UI elements |
| `src/test/` | Tests updated to reflect all 52 weeks having full content |

## Test plan

- [x] All 61 unit tests pass
- [x] Build is clean (`vite build` succeeds)
- [ ] Verify "Today" card on Home screen shows the correct day-specific fact
- [ ] Verify all weeks in the Weeks tab show full content (no "coming soon")
- [ ] Verify Week detail view shows the "Daily insights" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)